### PR TITLE
Fix bug in dcm discovery where zero-length resp-data can cause crash

### DIFF
--- a/tool/can_actions.py
+++ b/tool/can_actions.py
@@ -52,7 +52,6 @@ class CanActions():
         self.notifier = can.Notifier(self.bus, listeners=[])
         self.arb_id = arb_id
         self.bruteforce_running = False
-        self.opaque_data = {}
 
     def __enter__(self):
         return self

--- a/tool/can_actions.py
+++ b/tool/can_actions.py
@@ -52,7 +52,7 @@ class CanActions():
         self.notifier = can.Notifier(self.bus, listeners=[])
         self.arb_id = arb_id
         self.bruteforce_running = False
-        self.found_diagnostics = False
+        self.opaque_data = {}
 
     def __enter__(self):
         return self

--- a/tool/can_actions.py
+++ b/tool/can_actions.py
@@ -52,6 +52,7 @@ class CanActions():
         self.notifier = can.Notifier(self.bus, listeners=[])
         self.arb_id = arb_id
         self.bruteforce_running = False
+        self.found_diagnostics = False
 
     def __enter__(self):
         return self

--- a/tool/modules/dcm.py
+++ b/tool/modules/dcm.py
@@ -177,7 +177,7 @@ def dcm_discovery(args):
             def response_analyser(msg):
                 # Catch both ok and negative response
                 if len(msg.data) >= 2 and msg.data[1] in [0x50, 0x7F]:
-                    can_wrap.found_diagnostics = True
+                    can_wrap.opaque_data['diagnostics_found'] = True
                     print("\nFound diagnostics at arbitration ID 0x{0:04x}, "
                           "reply at 0x{1:04x}".format(arb_id, msg.arbitration_id))
                     if no_stop == False:
@@ -185,7 +185,7 @@ def dcm_discovery(args):
             return response_analyser
 
         def discovery_finished(s):
-            if can_wrap.found_diagnostics:
+            if can_wrap.opaque_data.get('diagnostics_found', None) == True:
                 print("\n{0}".format(s))
             else:
                 print("\nDiagnostics service could not be found: {0}".format(s))

--- a/tool/modules/dcm.py
+++ b/tool/modules/dcm.py
@@ -166,6 +166,8 @@ def dcm_discovery(args):
     min_id = int_from_str_base(args.min)
     max_id = int_from_str_base(args.max)
     no_stop = args.nostop
+    class Diagnostics:
+        found = False
 
     with CanActions() as can_wrap:
         print("Starting diagnostics service discovery")
@@ -177,7 +179,7 @@ def dcm_discovery(args):
             def response_analyser(msg):
                 # Catch both ok and negative response
                 if len(msg.data) >= 2 and msg.data[1] in [0x50, 0x7F]:
-                    can_wrap.opaque_data['diagnostics_found'] = True
+                    Diagnostics.found = True
                     print("\nFound diagnostics at arbitration ID 0x{0:04x}, "
                           "reply at 0x{1:04x}".format(arb_id, msg.arbitration_id))
                     if no_stop == False:
@@ -185,7 +187,7 @@ def dcm_discovery(args):
             return response_analyser
 
         def discovery_finished(s):
-            if can_wrap.opaque_data.get('diagnostics_found', None) == True:
+            if Diagnostics.found:
                 print("\n{0}".format(s))
             else:
                 print("\nDiagnostics service could not be found: {0}".format(s))


### PR DESCRIPTION
Fix bug in dcm discovery where zero-length resp-data can cause crash; Add "nostop" arg to dcm discovery to not stop at first item found (defaults to NOT stopping)