### PR TITLE
Graceful quit of UDS service discovery via exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ The target ECU used for the development setup is an STM32F107 based dev-board fr
 * Craig Smith (OpenGarages.org)
 * internot
 * Mathijs Hubrechtsen
+* Lear Corporation


### PR DESCRIPTION
Data was lost when user interrupted the uds discovery function. After this change, the KeyboardInterrupt is caught earlier so the found services can still be displayed to the user, thus preventing data loss.