### PR TITLE
Implemented optionally extending CAN IDs within iso15765

### DIFF
--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -77,11 +77,7 @@ class IsoTp:
         :param arbitration_id: Arbitration ID to use
         :return: None
         """
-        if arbitration_id <= ARBITRATION_ID_MAX:
-            is_extended = force_extended or False
-        else:
-            is_extended = True
-
+        is_extended = force_extended or arbitration_id > ARBITRATION_ID_MAX
         msg = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=is_extended)
         self.bus.send(msg)
 

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -1,5 +1,5 @@
 from lib.can_actions import DEFAULT_INTERFACE
-from lib.constants import ARBITRATION_ID_MAX_EXTENDED
+from lib.constants import ARBITRATION_ID_MAX_EXTENDED, ARBITRATION_ID_MAX
 import can
 import datetime
 import time
@@ -69,7 +69,7 @@ class IsoTp:
         """Remove arbitration ID filters"""
         self._set_filters(None)
 
-    def send_message(self, data, arbitration_id):
+    def send_message(self, data, arbitration_id, force_extended=False):
         """
         Transmits a message using 'arbitration_id' and 'data' on 'self.bus'
 
@@ -77,7 +77,12 @@ class IsoTp:
         :param arbitration_id: Arbitration ID to use
         :return: None
         """
-        msg = can.Message(arbitration_id=arbitration_id, data=data)
+        if arbitration_id <= ARBITRATION_ID_MAX:
+            is_extended = force_extended or False
+        else:
+            is_extended = True
+
+        msg = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=is_extended)
         self.bus.send(msg)
 
     def decode_sf(self, frame):


### PR DESCRIPTION
Before this change, all CAN frames were sent in extended-ID mode, even if the ID was less than 0x7ff. This caused undesired behavior on vehicle and bench testing using PCAN-USB tools where the receiving module ignored extended-ID CAN frames. 

After this change, the iso15765 implementation by default does not extend the CAN IDs unless
they exceed 0x7ff. This can be overridden by an API parameter: "force_extended".