### PR TITLE
Addresses Issue #52 - Interface Agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ We are lacking a security testing tool for automotive. A zero-knowledge tool tha
 
 This work was initiated as part of the research project HEAVENS (HEAling Vulnerabilities to ENhance Software Security and Safety), but lives on as a stand-alone project.
 
+## Hardware requirements
+Some sort of CAN bus interface compatible with socketCAN (http://elinux.org/CAN_Bus#CAN_Support_in_Linux) or supported directly by python-can (https://python-can.readthedocs.io/en/3.1.1/interfaces.html)
+
+## Software requirements
+- Python 2.7 or 3.x
+- python-can v3.1.1
+- a pretty modern linux kernel
+
+## How to install
+Instructions available [here](documentation/howtoinstall.md)
+
+
 ## How to use
 The best way to understand how to use Caring Caribou is to look at the help screen:
 
@@ -102,17 +114,6 @@ Implementation of the ISO-14229-1 standard for Unified Diagnostic Services (UDS)
 ### iso15765_2.py
 Implementation of the ISO-15765-2 standard (ISO-TP). This is a transport protocol which enables sending of messages longer than 8 bytes over CAN by splitting them into multiple data frames.
 
-## Hardware requirements
-Some sort of CAN bus interface compatible with socketCAN (http://elinux.org/CAN_Bus#CAN_Support_in_Linux)
-
-## Software requirements
-- Python 2.7 or 3.x
-- python-can
-- a pretty modern linux kernel
-
-## How to install
-Instructions available [here](documentation/howtoinstall.md)
-
 ## Extending the project
 Create a python file with a function `module_main(args)` and put it in the ```tool/modules``` folder. Caring Caribou will automagically recognize it as a module and list it in the output of `./cc.py -h`
 
@@ -134,3 +135,4 @@ The target ECU used for the development setup is an STM32F107 based dev-board fr
 * Craig Smith (OpenGarages.org)
 * internot
 * Mathijs Hubrechtsen
+* Lear Corporation

--- a/tool/cc.py
+++ b/tool/cc.py
@@ -65,9 +65,14 @@ def parse_arguments():
     :return: Namespace containing module name and arguments
     :rtype: argparse.Namespace
     """
-    parser = argparse.ArgumentParser(description="{0}A friendly car security exploration tool".format(fancy_header()),
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=available_modules())
+    parser = argparse.ArgumentParser(
+            description="{0}A friendly car security "
+            "exploration tool.\n\nBe sure to setup and configure "
+		    "Python-CAN before continuing.\nFor help on how to configure,"
+		    " see\nhttps://python-can.readthedocs.io/en/3.1.1/configurati"
+		    "on.html".format(fancy_header()),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=available_modules())
     parser.add_argument("module",
                         help="Name of the module to run")
     parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,

--- a/tool/cc.py
+++ b/tool/cc.py
@@ -68,8 +68,6 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description="{0}A friendly car security exploration tool".format(fancy_header()),
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      epilog=available_modules())
-    parser.add_argument("-i", dest="interface", default=None,
-                        help="force interface, e.g. 'can1' or 'vcan0'")
     parser.add_argument("module",
                         help="Name of the module to run")
     parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,
@@ -105,9 +103,6 @@ def main():
     args = parse_arguments()
     # Show header
     show_script_header()
-    # Save interface to can_actions, for use in modules
-    if args.interface:
-        lib.can_actions.DEFAULT_INTERFACE = args.interface
     # Dynamically load module
     mod = load_module(args.module)
     if mod is not None:

--- a/tool/lib/can_actions.py
+++ b/tool/lib/can_actions.py
@@ -13,11 +13,6 @@ MESSAGE_DELAY = 0.1
 DELAY_STEP = 0.02
 NOTIFIER_STOP_DURATION = 0.5
 
-# Global CAN interface setting, which can be set through the -i flag to cc.py
-# The value None corresponds to the default CAN interface (typically can0)
-DEFAULT_INTERFACE = None
-
-
 def auto_blacklist(bus, duration, classifier_function, print_results):
     """Listens for false positives on the CAN bus and generates an arbitration ID blacklist.
 
@@ -75,7 +70,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+        self.bus = can.Bus()
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -1,4 +1,3 @@
-from lib.can_actions import DEFAULT_INTERFACE
 from lib.constants import ARBITRATION_ID_MAX_EXTENDED
 import can
 import datetime
@@ -38,7 +37,7 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+            self.bus = can.Bus()
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request

--- a/tool/modules/test.py
+++ b/tool/modules/test.py
@@ -1,11 +1,10 @@
 from __future__ import print_function
-from lib.can_actions import DEFAULT_INTERFACE
 import unittest
 
 
 def print_interface_header():
     """Prints a header showing which interface is used"""
-    interface_str = DEFAULT_INTERFACE if DEFAULT_INTERFACE is not None else "default"
+    interface_str = "default"
     message = "Running tests using CAN interface '{0}'\n".format(interface_str)
     print(message)
 

--- a/tool/tests/mock/mock_ecu.py
+++ b/tool/tests/mock/mock_ecu.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from lib.can_actions import DEFAULT_INTERFACE
 import can
 
 
@@ -11,7 +10,7 @@ class MockEcu:
     def __init__(self, bus=None):
         self.message_process = None
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+            self.bus = can.Bus(bustype="socketcan")
         else:
             self.bus = bus
 

--- a/tool/tests/test_iso_14229_1.py
+++ b/tool/tests/test_iso_14229_1.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from lib.can_actions import DEFAULT_INTERFACE
 from tests.mock.mock_ecu_uds import MockEcuIso14229
 from lib import iso14229_1
 from lib import iso15765_2
@@ -17,7 +16,7 @@ class DiagnosticsOverIsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIso14229(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+        can_bus = can.Bus(bustype="socketcan")
         # Setup diagnostics on top of ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
         self.diagnostics = iso14229_1.Iso14229_1(self.tp)

--- a/tool/tests/test_iso_15765_2.py
+++ b/tool/tests/test_iso_15765_2.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from tests.mock.mock_ecu_iso_tp import MockEcuIsoTp
 from lib import iso15765_2
-from lib.can_actions import DEFAULT_INTERFACE
 import can
 import unittest
 
@@ -16,7 +15,7 @@ class IsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+        can_bus = can.Bus(bustype="socketcan")
         # Setup ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
 


### PR DESCRIPTION
 Removed -i flag from cc.py and removed references to DEFAULT_INTERFACE.

 The Python-Can library supports more than just SocketCAN, and by removing the -i
 flag, more control is given to python-can and configuration occurs at that layer.