### PR TITLE
Initial working implementation for security_seed (Issue #12)

### DIFF
--- a/tool/cc.py
+++ b/tool/cc.py
@@ -11,7 +11,8 @@ import os
 
 VERSION = "0.3"
 
-# Find the right "modules" directory, even if the script is run from another directory
+# Find the right "modules" directory, even if
+# the script is run from another directory
 MODULES_DIR = "modules"
 
 
@@ -51,7 +52,8 @@ def available_modules():
     :rtype: str
     """
     blacklisted_files = ["__init__.py"]
-    modules = [m[:-3] for m in os.listdir(MODULES_DIR) if m.endswith(".py") and m not in blacklisted_files]
+    modules = [m[:-3] for m in os.listdir(MODULES_DIR) if m.endswith(".py")
+               and m not in blacklisted_files]
     modules.sort()
     mod_str = "available modules:\n  "
     mod_str += ", ".join(modules)
@@ -65,14 +67,18 @@ def parse_arguments():
     :return: Namespace containing module name and arguments
     :rtype: argparse.Namespace
     """
-    parser = argparse.ArgumentParser(description="{0}A friendly car security exploration tool".format(fancy_header()),
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=available_modules())
+    parser = argparse.ArgumentParser(
+      description="{0}A friendly car security exploration tool".format(
+        fancy_header()),
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      epilog=available_modules())
+
     parser.add_argument("-i", dest="interface", default=None,
                         help="force interface, e.g. 'can1' or 'vcan0'")
     parser.add_argument("module",
                         help="Name of the module to run")
-    parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,
+    parser.add_argument("module_args", metavar="...",
+                        nargs=argparse.REMAINDER,
                         help="Arguments to module")
     args = parser.parse_args()
     return args
@@ -82,11 +88,13 @@ def load_module(module_name):
     """
     Dynamically imports module_name from the folder specified by MODULES_DIR.
 
-    :param str module_name: Name of the module to import (without file extension)
-                            e.g. "listener" if module is stored in "./modules/listener.py"
+    :param str module_name: Name of the module to import (without file
+                            extension) e.g. "listener" if module is stored
+                            in "./modules/listener.py"
     :return: a loaded module on success, None otherwise
     """
-    # Clean module name (since module location is decided by MODULES_DIR, we don't take a full path)
+    # Clean module name (since module location is decided by MODULES_DIR,
+    # we don't take a full path)
     clean_mod_name = os.path.basename(module_name)
     package = "{0}.{1}".format(MODULES_DIR, clean_mod_name)
     try:
@@ -112,13 +120,15 @@ def main():
     mod = load_module(args.module)
     if mod is not None:
         func_name = "module_main"
-        func_exists = func_name in dir(mod) and callable(getattr(mod, func_name))
+        func_exists = func_name in dir(mod) and callable(
+          getattr(mod, func_name))
         if func_exists:
             # Run module, passing any remaining arguments
             mod.module_main(args.module_args)
         else:
             # Print error message if module_main is missing
-            print("ERROR: Module '{0}' does not contain a '{1}' function.".format(args.module, func_name))
+            print("ERROR: Module '{0}' does not contain a '{1}' "
+                  "function.".format(args.module, func_name))
 
 
 # Main wrapper
@@ -131,8 +141,10 @@ if __name__ == '__main__':
         print("\nCanError: {0}".format(e))
     except IOError as e:
         if e.errno is errno.ENODEV:
-            # Specifically catch "[Errno 19] No such device", which is caused by using an invalid interface
-            print("\nIOError: {0}. This might be caused by an invalid or inactive CAN interface.".format(e))
+            # Specifically catch "[Errno 19] No such device", which is
+            # caused by using an invalid interface
+            print("\nIOError: {0}. This might be caused by an invalid "
+                  "or inactive CAN interface.".format(e))
         else:
             # Print original stack trace
             traceback.print_exc()

--- a/tool/cc.py
+++ b/tool/cc.py
@@ -11,8 +11,7 @@ import os
 
 VERSION = "0.3"
 
-# Find the right "modules" directory, even if
-# the script is run from another directory
+# Find the right "modules" directory, even if the script is run from another directory
 MODULES_DIR = "modules"
 
 
@@ -52,8 +51,7 @@ def available_modules():
     :rtype: str
     """
     blacklisted_files = ["__init__.py"]
-    modules = [m[:-3] for m in os.listdir(MODULES_DIR) if m.endswith(".py")
-               and m not in blacklisted_files]
+    modules = [m[:-3] for m in os.listdir(MODULES_DIR) if m.endswith(".py") and m not in blacklisted_files]
     modules.sort()
     mod_str = "available modules:\n  "
     mod_str += ", ".join(modules)
@@ -67,18 +65,14 @@ def parse_arguments():
     :return: Namespace containing module name and arguments
     :rtype: argparse.Namespace
     """
-    parser = argparse.ArgumentParser(
-      description="{0}A friendly car security exploration tool".format(
-        fancy_header()),
-      formatter_class=argparse.RawDescriptionHelpFormatter,
-      epilog=available_modules())
-
+    parser = argparse.ArgumentParser(description="{0}A friendly car security exploration tool".format(fancy_header()),
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog=available_modules())
     parser.add_argument("-i", dest="interface", default=None,
                         help="force interface, e.g. 'can1' or 'vcan0'")
     parser.add_argument("module",
                         help="Name of the module to run")
-    parser.add_argument("module_args", metavar="...",
-                        nargs=argparse.REMAINDER,
+    parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,
                         help="Arguments to module")
     args = parser.parse_args()
     return args
@@ -88,13 +82,11 @@ def load_module(module_name):
     """
     Dynamically imports module_name from the folder specified by MODULES_DIR.
 
-    :param str module_name: Name of the module to import (without file
-                            extension) e.g. "listener" if module is stored
-                            in "./modules/listener.py"
+    :param str module_name: Name of the module to import (without file extension)
+                            e.g. "listener" if module is stored in "./modules/listener.py"
     :return: a loaded module on success, None otherwise
     """
-    # Clean module name (since module location is decided by MODULES_DIR,
-    # we don't take a full path)
+    # Clean module name (since module location is decided by MODULES_DIR, we don't take a full path)
     clean_mod_name = os.path.basename(module_name)
     package = "{0}.{1}".format(MODULES_DIR, clean_mod_name)
     try:
@@ -120,15 +112,13 @@ def main():
     mod = load_module(args.module)
     if mod is not None:
         func_name = "module_main"
-        func_exists = func_name in dir(mod) and callable(
-          getattr(mod, func_name))
+        func_exists = func_name in dir(mod) and callable(getattr(mod, func_name))
         if func_exists:
             # Run module, passing any remaining arguments
             mod.module_main(args.module_args)
         else:
             # Print error message if module_main is missing
-            print("ERROR: Module '{0}' does not contain a '{1}' "
-                  "function.".format(args.module, func_name))
+            print("ERROR: Module '{0}' does not contain a '{1}' function.".format(args.module, func_name))
 
 
 # Main wrapper
@@ -141,10 +131,8 @@ if __name__ == '__main__':
         print("\nCanError: {0}".format(e))
     except IOError as e:
         if e.errno is errno.ENODEV:
-            # Specifically catch "[Errno 19] No such device", which is
-            # caused by using an invalid interface
-            print("\nIOError: {0}. This might be caused by an invalid "
-                  "or inactive CAN interface.".format(e))
+            # Specifically catch "[Errno 19] No such device", which is caused by using an invalid interface
+            print("\nIOError: {0}. This might be caused by an invalid or inactive CAN interface.".format(e))
         else:
             # Print original stack trace
             traceback.print_exc()

--- a/tool/lib/iso14229_1.py
+++ b/tool/lib/iso14229_1.py
@@ -2,7 +2,8 @@ import time
 
 
 class DynamicallyDefinedIdentifierArg(object):
-    def __init__(self, source_data_identifier, position_in_source_data_record, memory_size):
+    def __init__(self, source_data_identifier,
+                 position_in_source_data_record, memory_size):
         self.sourceDataIdentifier = source_data_identifier
         self.positionInSourceDataRecord = position_in_source_data_record
         self.memorySize = memory_size
@@ -109,7 +110,7 @@ class BaseService(object):
 
 class Services(object):
     """Class structure containing service specific constants, sub-function
-    parameters and functions"""
+       parameters and functions"""
 
     class DiagnosticSessionControl(BaseService):
 
@@ -129,23 +130,6 @@ class Services(object):
             SYSTEM_SUPPLIER_SESSION_MIN = 0x60
             SYSTEM_SUPPLIER_SESSION_MAX = 0x7E
             # 0x7F ISO SAE Reserved
-            def is_valid_session(self, sub_function):
-                """Returns True if 'sub_function' is a valid session type and
-                False otherwise"""
-                #Strip off the MSB which is used as flag to suppress responses
-                #so we don't care what it is
-                sub_function = 0x7f & sub_function
-                if (sub_function is self.DEFAULT_SESSION
-                    or sub_function is self.PROGRAMMING_SESSION
-                    or sub_function is self.EXTENDED_DIAGNOSTIC_SESSION
-                    or sub_function is self.SAFETY_SYSTEM_DIAGNOSTIC_SESSION
-                    or(sub_function <= self.VEHICLE_MANUFACTURER_SESSION_MAX and
-                        sub_function >= self.VEHICLE_MANUFACTURER_SESSION_MIN)
-                    or(sub_function <= self.SYSTEM_SUPPLIER_SESSION_MAX and
-                        sub_function >= self.SYSTEM_SUPPLIER_SESSION_MIN)):
-                    return True
-                else:
-                    return False
 
     class EcuReset(BaseService):
 
@@ -169,7 +153,8 @@ class Services(object):
 
         class RequestSeedOrSendKey(object):
             """
-            These are lined up so that value X "request seed level N" has a matching "send key level N" at value X+1.
+            These are lined up so that value X "request seed level N" has
+            a matching "send key level N" at value X+1.
 
             0x01 is Request seed level 0x01
             0x02 is Send key level 0x01
@@ -179,11 +164,13 @@ class Services(object):
             0x41 is Request seed level 0x21
             0x42 is Send key level 0x21
 
-            The security levels numbering is arbitrary and does not imply any relationship between the levels.
+            The security levels numbering is arbitrary and does not imply
+            any relationship between the levels.
             """
 
             # 0x00 ISO SAE Reserved
-            # 0x01-0x42 Vehicle manufacturer specific request seed/send key pairs
+            # 0x01-0x42 Vehicle manufacturer specific request
+            #           seed/send key pairs
             # 0x43-0X5E ISO SAE Reserved
             ISO_26021_2_VALUES = 0x5F
             ISO_26021_2_SEND_KEY = 0x60
@@ -196,16 +183,20 @@ class Services(object):
             __SEND_KEY_MAX = 0x42
 
             def is_valid_request_seed_level(self, sub_function):
-                """Returns True if 'sub_function' is a valid request seed value and False otherwise"""
+                """Returns True if 'sub_function' is a valid request seed
+                   value and False otherwise"""
                 value = sub_function & 0x7F
-                valid_interval = self.__REQUEST_SEED_MIN <= value <= self.__REQUEST_SEED_MAX
+                valid_interval = self.__REQUEST_SEED_MIN \
+                    <= value <= self.__REQUEST_SEED_MAX
                 is_odd = value % 2 == 1
                 return valid_interval and is_odd
 
             def is_valid_send_key_level(self, sub_function):
-                """Returns True if 'sub_function' is a valid send key value and False otherwise"""
+                """Returns True if 'sub_function' is a valid send key value
+                   and False otherwise"""
                 value = sub_function & 0x7F
-                valid_interval = self.__SEND_KEY_MIN <= value <= self.__SEND_KEY_MAX
+                valid_interval = self.__SEND_KEY_MIN \
+                    <= value <= self.__SEND_KEY_MAX
                 is_even = value % 2 == 0
                 return valid_interval and is_even
 
@@ -219,9 +210,11 @@ class Services(object):
 
 
 class Constants(object):
-    # NR_SI (Negative Response Service Identifier) is a bit special, since it is not a service per se.
-    # From ISO-14229-1 specification: "The NR_SI value is co-ordinated with the SI values. The NR_SI
-    # value is not used as a SI value in order to make A_Data coding and decoding easier."
+    # NR_SI (Negative Response Service Identifier) is a bit special, since
+    # it is not a service per se.
+    # From ISO-14229-1 specification: "The NR_SI value is co-ordinated with
+    # the SI values. The NR_SI value is not used as a SI value in order to
+    # make A_Data coding and decoding easier."
     NR_SI = 0x7F
 
 
@@ -249,7 +242,8 @@ class Iso14229_1(object):
 
     def send_request(self, data):
         """
-        Sends a request message containing 'data' through the underlying TP layer
+        Sends a request message containing 'data' through the underlying
+        TP layer
 
         :param data: The data to send
         :return: None
@@ -258,7 +252,8 @@ class Iso14229_1(object):
 
     def send_response(self, data):
         """
-        Sends a response message containing 'data' through the underlying TP layer
+        Sends a response message containing 'data' through the underlying
+        TP layer
 
         :param data: The data to send
         :return: None
@@ -282,7 +277,8 @@ class Iso14229_1(object):
             response = self.tp.indication(wait_window)
             if response is not None and len(response) > 3:
                 if response[0] == Constants.NR_SI and \
-                        response[2] == NegativeResponseCodes.REQUEST_CORRECTLY_RECEIVED_RESPONSE_PENDING:
+                    response[2] == NegativeResponseCodes\
+                        .REQUEST_CORRECTLY_RECEIVED_RESPONSE_PENDING:
                     continue
             break
         return response
@@ -296,7 +292,9 @@ class Iso14229_1(object):
         :return: False if response is a NEGATIVE_RESPONSE,
                  True otherwise
         """
-        if response is not None and len(response) > 0 and response[0] != Constants.NR_SI:
+        if(response is not None and
+           len(response) > 0 and
+           response[0] != Constants.NR_SI):
             return True
         return False
 
@@ -320,7 +318,8 @@ class Iso14229_1(object):
             response = self.receive_response(self.P3_CLIENT)
         return response
 
-    def read_memory_by_address(self, address_and_length_format, memory_address, memory_size):
+    def read_memory_by_address(self, address_and_length_format,
+                               memory_address, memory_size):
         """
         Sends a "read memory by address" request for 'memory_address'
 
@@ -338,13 +337,15 @@ class Iso14229_1(object):
         request[1] = address_and_length_format
         offset = 2
         for i in (range(0, address_size_format)):
-            request[address_size_format + offset - i - 1] = (memory_address & 0xFF)
+            request[address_size_format + offset - i - 1] = \
+                (memory_address & 0xFF)
             memory_address = (memory_address >> 8)
 
         offset += address_size_format
 
         for i in (range(0, data_size_format)):
-            request[data_size_format + offset - i - 1] = (memory_size & 0xFF)
+            request[data_size_format + offset - i - 1] = \
+                (memory_size & 0xFF)
             memory_size = (memory_size >> 8)
 
         self.tp.send_request(request)
@@ -352,9 +353,11 @@ class Iso14229_1(object):
 
         return response
 
-    def write_memory_by_address(self, address_and_length_format, memory_address, memory_size, data):
+    def write_memory_by_address(self, address_and_length_format,
+                                memory_address, memory_size, data):
         """
-        Sends a "write memory by address" request to write 'data' to 'memory_address'
+        Sends a "write memory by address" request to write 'data' to
+        'memory_address'
 
         :param address_and_length_format: Address and length format
         :param memory_address: Memory address
@@ -371,13 +374,15 @@ class Iso14229_1(object):
         request[1] = address_and_length_format
         offset = 2
         for i in (range(0, address_size_format)):
-            request[address_size_format + offset - i - 1] = (memory_address & 0xFF)
+            request[address_size_format + offset - i - 1] = \
+                (memory_address & 0xFF)
             memory_address = (memory_address >> 8)
 
         offset += address_size_format
 
         for i in (range(0, data_size_format)):
-            request[data_size_format + offset - i - 1] = (memory_size & 0xFF)
+            request[data_size_format + offset - i - 1] = \
+                (memory_size & 0xFF)
             memory_size = (memory_size >> 8)
 
         request += data
@@ -388,7 +393,8 @@ class Iso14229_1(object):
 
     def write_data_by_identifier(self, identifier, data):
         """
-        Sends a "write data by identifier" request to write 'data' to 'identifier'
+        Sends a "write data by identifier" request to write 'data' to
+        'identifier'
 
         :param identifier: Data identifier
         :param data: Data to write to 'identifier'
@@ -408,7 +414,8 @@ class Iso14229_1(object):
 
     def input_output_control_by_identifier(self, identifier, data):
         """
-        Sends a "input output control by identifier" request for 'data' to 'identifier'
+        Sends a "input output control by identifier" request for 'data' to
+        'identifier'
 
         :param identifier: Data identifier
         :param data: Data
@@ -427,9 +434,11 @@ class Iso14229_1(object):
 
         return response
 
-    def dynamically_define_data_identifier(self, identifier, sub_function, sub_function_arg):
+    def dynamically_define_data_identifier(self, identifier,
+                                           sub_function, sub_function_arg):
         """
-        Sends a "dynamically define data identifier" request for 'identifier'
+        Sends a "dynamically define data identifier" request for
+        'identifier'
 
         :param identifier: DDDID to set
         :param sub_function: Sub function
@@ -437,7 +446,9 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        if identifier is None or sub_function is None or sub_function_arg is None:
+        if(identifier is None or
+           sub_function is None or
+           sub_function_arg is None):
             return None
 
         request = [0] * (1 + 1 + 2 + len(sub_function_arg) * 4)
@@ -461,9 +472,11 @@ class Iso14229_1(object):
 
     def diagnostic_session_control(self, session_type):
         """
-        Sends a "DiagnosticSessionControl" request for specified session type
+        Sends a "DiagnosticSessionControl" request for specified session
+        type
 
-        :param session_type: Indicates which kind of session should be requested
+        :param session_type: Indicates which kind of session should be
+                             requested
         :return: Response data if successful,
                  None otherwise
         """
@@ -475,7 +488,6 @@ class Iso14229_1(object):
         response = self.receive_response(self.P3_CLIENT)
 
         return response
-
 
     def ecu_reset(self, reset_type):
         """
@@ -499,7 +511,8 @@ class Iso14229_1(object):
         Sends a Security Access "Request seed" message for 'level'
 
         :param level: Security Access Type level to send request seed for
-        :param data_record: Optional data to transmit when requesting seed, e.g. client identification
+        :param data_record: Optional data to transmit when requesting seed,
+                            e.g. client identification
         :return: Response data (containing seed) if successful,
                  None otherwise
         """
@@ -533,7 +546,8 @@ class Iso14229_1(object):
 
         return response
 
-    def read_data_by_periodic_identifier(self, transmission_mode, identifier):
+    def read_data_by_periodic_identifier(self, transmission_mode,
+                                         identifier):
         """
         Sends a "read data by periodic identifier" request for 'identifier'
 
@@ -542,7 +556,9 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        if transmission_mode is None or identifier is None or len(identifier) == 0:
+        if(transmission_mode is None or
+           identifier is None or
+           len(identifier) == 0):
             return None
 
         request = [0] * (2 + len(identifier))

--- a/tool/lib/iso14229_1.py
+++ b/tool/lib/iso14229_1.py
@@ -186,8 +186,8 @@ class Services(object):
                 """Returns True if 'sub_function' is a valid request seed
                    value and False otherwise"""
                 value = sub_function & 0x7F
-                valid_interval = self.__REQUEST_SEED_MIN \
-                    <= value <= self.__REQUEST_SEED_MAX
+                valid_interval = (self.__REQUEST_SEED_MIN
+                                  <= value <= self.__REQUEST_SEED_MAX)
                 is_odd = value % 2 == 1
                 return valid_interval and is_odd
 
@@ -195,8 +195,8 @@ class Services(object):
                 """Returns True if 'sub_function' is a valid send key value
                    and False otherwise"""
                 value = sub_function & 0x7F
-                valid_interval = self.__SEND_KEY_MIN \
-                    <= value <= self.__SEND_KEY_MAX
+                valid_interval = (self.__SEND_KEY_MIN
+                                  <= value <= self.__SEND_KEY_MAX)
                 is_even = value % 2 == 0
                 return valid_interval and is_even
 
@@ -275,10 +275,11 @@ class Iso14229_1(object):
                 return None
 
             response = self.tp.indication(wait_window)
+            NRC = NegativeResponseCodes
+            NRC_RCRRP = NRC.REQUEST_CORRECTLY_RECEIVED_RESPONSE_PENDING
             if response is not None and len(response) > 3:
-                if response[0] == Constants.NR_SI and \
-                    response[2] == NegativeResponseCodes\
-                        .REQUEST_CORRECTLY_RECEIVED_RESPONSE_PENDING:
+                if (response[0] == Constants.NR_SI and
+                   response[2] == NRC_RCRRP):
                     continue
             break
         return response
@@ -292,7 +293,7 @@ class Iso14229_1(object):
         :return: False if response is a NEGATIVE_RESPONSE,
                  True otherwise
         """
-        if(response is not None and
+        if (response is not None and
            len(response) > 0 and
            response[0] != Constants.NR_SI):
             return True
@@ -329,23 +330,21 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        address_size_format = (address_and_length_format >> 4) & 0xF
-        data_size_format = (address_and_length_format & 0xF)
+        addr_sz_fmt = (address_and_length_format >> 4) & 0xF
+        data_sz_fmt = (address_and_length_format & 0xF)
 
-        request = [0] * (1 + 1 + address_size_format + data_size_format)
+        request = [0] * (1 + 1 + addr_sz_fmt + data_sz_fmt)
         request[0] = ServiceID.READ_MEMORY_BY_ADDRESS
         request[1] = address_and_length_format
         offset = 2
-        for i in (range(0, address_size_format)):
-            request[address_size_format + offset - i - 1] = \
-                (memory_address & 0xFF)
+        for i in (range(0, addr_sz_fmt)):
+            request[addr_sz_fmt + offset - i - 1] = (memory_address & 0xFF)
             memory_address = (memory_address >> 8)
 
-        offset += address_size_format
+        offset += addr_sz_fmt
 
-        for i in (range(0, data_size_format)):
-            request[data_size_format + offset - i - 1] = \
-                (memory_size & 0xFF)
+        for i in (range(0, data_sz_fmt)):
+            request[data_sz_fmt + offset - i - 1] = (memory_size & 0xFF)
             memory_size = (memory_size >> 8)
 
         self.tp.send_request(request)
@@ -366,23 +365,21 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        address_size_format = (address_and_length_format >> 4) & 0xF
-        data_size_format = (address_and_length_format & 0xF)
+        addr_sz_fmt = (address_and_length_format >> 4) & 0xF
+        data_sz_fmt = (address_and_length_format & 0xF)
 
-        request = [0] * (1 + 1 + address_size_format + data_size_format)
+        request = [0] * (1 + 1 + addr_sz_fmt + data_sz_fmt)
         request[0] = ServiceID.WRITE_MEMORY_BY_ADDRESS
         request[1] = address_and_length_format
         offset = 2
-        for i in (range(0, address_size_format)):
-            request[address_size_format + offset - i - 1] = \
-                (memory_address & 0xFF)
+        for i in (range(0, addr_sz_fmt)):
+            request[addr_sz_fmt + offset - i - 1] = (memory_address & 0xFF)
             memory_address = (memory_address >> 8)
 
-        offset += address_size_format
+        offset += addr_sz_fmt
 
-        for i in (range(0, data_size_format)):
-            request[data_size_format + offset - i - 1] = \
-                (memory_size & 0xFF)
+        for i in (range(0, data_sz_fmt)):
+            request[data_sz_fmt + offset - i - 1] = (memory_size & 0xFF)
             memory_size = (memory_size >> 8)
 
         request += data
@@ -446,7 +443,7 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        if(identifier is None or
+        if (identifier is None or
            sub_function is None or
            sub_function_arg is None):
             return None
@@ -556,7 +553,7 @@ class Iso14229_1(object):
         :return: Response data if successful,
                  None otherwise
         """
-        if(transmission_mode is None or
+        if (transmission_mode is None or
            identifier is None or
            len(identifier) == 0):
             return None

--- a/tool/lib/iso14229_1.py
+++ b/tool/lib/iso14229_1.py
@@ -288,7 +288,7 @@ class Iso14229_1(object):
         """
         Returns a bool indicating whether 'response' is positive
 
-        :param response: Response data after CAN-TP layer has been removed
+        :param response: ISO-14229-1 response data
         :return: False if response is a NEGATIVE_RESPONSE,
                  True otherwise
         """

--- a/tool/modules/send.py
+++ b/tool/modules/send.py
@@ -238,7 +238,7 @@ def parse_args(args):
   cc.py send file -d 0.2 can_dump.txt""")
     subparsers = parser.add_subparsers(dest="module_function")
     subparsers.required = True
-    
+
     # Parser for sending messages from command line
     cmd_msgs = subparsers.add_parser("message")
     cmd_msgs.add_argument("msg", nargs="+",

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -818,20 +818,21 @@ def __parse_args(args):
     parser_secseed.add_argument("dst",
                                 type=parse_int_dec_or_hex,
                                 help="arbitration ID to listen to")
-    parser_secseed.add_argument("-r", "--reset", metavar="rtype",
+    parser_secseed.add_argument("-r", "--reset", metavar="RTYPE",
                                 type=parse_int_dec_or_hex,
                                 help="Enable reset between security "
-                                "seed requests. Reset type: 1=hardReset, "
-                                "2=key off/on, 3=softReset, 4=enable rapid "
-                                "power shutdown, 5=disable rapid "
-                                "power shutdown")
+                                "seed requests. Valid RTYPE integers are: "
+                                "1=hardReset, 2=key off/on, 3=softReset, "
+                                "4=enable rapid power shutdown, "
+                                "5=disable rapid power shutdown. "
+                                "(default: None)")
     parser_secseed.add_argument("-d", "--delay", metavar="D",
                                 type=float, default=DELAY_SECSEED_RESET,
                                 help="Wait D seconds between reset and "
                                 "security seed request. You'll likely need "
-                                "to increase this when using reset type "
-                                "1=hardReset. Does nothing if no reset type"
-                                "is used. (default: {0})"
+                                "to increase this when using RTYPE: "
+                                "1=hardReset. Does nothing if RTYPE is None"
+                                ". (default: {0})"
                                 .format(DELAY_SECSEED_RESET))
     parser_secseed.add_argument("-n", "--num", metavar="NUM", default=0,
                                 type=parse_int_dec_or_hex,

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -511,8 +511,8 @@ def __security_seed_wrapper(args):
             if Iso14229_1.is_positive_response(response):
                 seed_list.append(list_to_hex_str(response[2:]))
                 print("Seed received: {}\t(Total captured: {})"
-			.format(list_to_hex_str(response[2:]),
-			len(seed_list)), end="\r")
+                        .format(list_to_hex_str(response[2:]),
+                        len(seed_list)), end="\r")
                 stdout.flush()
             else:
                 print_negative_response(response)

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 from lib.can_actions import auto_blacklist
 from lib.common import list_to_hex_str, parse_int_dec_or_hex
-from lib.constants import ARBITRATION_ID_MAX, ARBITRATION_ID_MAX_EXTENDED, ARBITRATION_ID_MIN
+from lib.constants import ARBITRATION_ID_MAX, ARBITRATION_ID_MAX_EXTENDED
+from lib.constants import ARBITRATION_ID_MIN
 from lib.iso15765_2 import IsoTp
 from lib.iso14229_1 import Iso14229_1, NegativeResponseCodes, Services
 from sys import stdout, version_info
@@ -102,14 +103,18 @@ BYTE_MIN = 0x00
 BYTE_MAX = 0xFF
 
 
-def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay, verify, print_results=True):
-    """Scans for diagnostics support by brute forcing session control messages to different arbitration IDs.
+def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration,
+                  delay, verify, print_results=True):
+    """Scans for diagnostics support by brute forcing session control
+        messages to different arbitration IDs.
+
     Returns a list of all (client_arb_id, server_arb_id) pairs found.
 
     :param min_id: start arbitration ID value
     :param max_id: end arbitration ID value
     :param blacklist_args: blacklist for arbitration ID values
-    :param auto_blacklist_duration: seconds to scan for interfering arbitration IDs to blacklist automatically
+    :param auto_blacklist_duration: seconds to scan for interfering
+      arbitration IDs to blacklist automatically
     :param delay: delay between each message
     :param verify: whether found arbitration IDs should be verified
     :param print_results: whether results should be printed to stdout
@@ -139,18 +144,23 @@ def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay
 
     # Sanity checks
     if max_id < min_id:
-        raise ValueError("max_id must not be smaller than min_id - got min:0x{0:x}, max:0x{1:x}".format(min_id, max_id))
+        raise ValueError("max_id must not be smaller than min_id -"
+                         " got min:0x{0:x}, max:0x{1:x}".format(
+                          min_id, max_id))
     if auto_blacklist_duration < 0:
-        raise ValueError("auto_blacklist_duration must not be smaller than 0, got {0}'".format(auto_blacklist_duration))
+        raise ValueError("auto_blacklist_duration must not be smaller "
+                         "than 0, got {0}'".format(auto_blacklist_duration))
 
-    service_id = Services.DiagnosticSessionControl.service_id
-    sub_function = Services.DiagnosticSessionControl.DiagnosticSessionType.DEFAULT_SESSION
+    S_DSC = Services.DiagnosticSessionControl
+    service_id = S_DSC.service_id
+    sub_function = S_DSC.DiagnosticSessionType.DEFAULT_SESSION
     session_control_data = [service_id, sub_function]
 
     valid_session_control_responses = [0x50, 0x7F]
 
     def is_valid_response(message):
-        return len(message.data) >= 2 and message.data[1] in valid_session_control_responses
+        return len(message.data) >= 2 and message.data[1] in \
+          valid_session_control_responses
 
     found_arbitration_ids = []
 
@@ -158,19 +168,23 @@ def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay
         blacklist = set(blacklist_args)
         # Perform automatic blacklist scan
         if auto_blacklist_duration > 0:
-            auto_blacklist_arb_ids = auto_blacklist(tp.bus, auto_blacklist_duration, is_valid_response, print_results)
+            auto_blacklist_arb_ids = auto_blacklist(
+              tp.bus, auto_blacklist_duration,
+              is_valid_response, print_results)
             blacklist |= auto_blacklist_arb_ids
 
         # Prepare session control frame
-        session_control_frames = tp.get_frames_from_message(session_control_data)
-        send_arbitration_id = min_id - 1
-        while send_arbitration_id < max_id:
-            send_arbitration_id += 1
+        session_control_frames = tp.get_frames_from_message(
+          session_control_data)
+        send_arb_id = min_id - 1
+        while send_arb_id < max_id:
+            send_arb_id += 1
             if print_results:
-                print("\rSending Diagnostic Session Control to 0x{0:04x}".format(send_arbitration_id), end="")
+                print("\rSending Diagnostic Session Control to 0x{0:04x}"
+                      .format(send_arb_id), end="")
                 stdout.flush()
             # Send Diagnostic Session Control
-            tp.transmit(session_control_frames, send_arbitration_id, None)
+            tp.transmit(session_control_frames, send_arb_id, None)
             end_time = time.time() + delay
             # Listen for response
             while time.time() < end_time:
@@ -184,19 +198,30 @@ def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay
                 if is_valid_response(msg):
                     # Valid response
                     if verify:
-                        # Verification - backtrack the latest IDs and verify that the same response is received
+                        # Verification - backtrack the latest IDs and
+                        # verify that the same response is received
                         verified = False
-                        # Set filter to only receive messages for the arbitration ID being verified
-                        tp.set_filter_single_arbitration_id(msg.arbitration_id)
+                        # Set filter to only receive messages for the
+                        # arbitration ID being verified
+                        tp.set_filter_single_arbitration_id(
+                          msg.arbitration_id)
                         if print_results:
-                            print("\n  Verifying potential response from 0x{0:04x}".format(send_arbitration_id))
-                        verify_id_range = range(send_arbitration_id, send_arbitration_id - VERIFICATION_BACKTRACK, -1)
-                        for verification_arbitration_id in verify_id_range:
+                            print("\n  Verifying potential response from "
+                                  "0x{0:04x}".format(send_arb_id))
+                        verify_id_range = range(send_arb_id,
+                                                send_arb_id
+                                                - VERIFICATION_BACKTRACK,
+                                                -1)
+                        for verify_arb_id in verify_id_range:
                             if print_results:
-                                print("    Resending 0x{0:0x}... ".format(verification_arbitration_id), end=" ")
-                            tp.transmit(session_control_frames, verification_arbitration_id, None)
-                            # Give some extra time for verification, in case of slow responses
-                            verification_end_time = time.time() + delay + VERIFICATION_EXTRA_DELAY
+                                print("    Resending 0x{0:0x}... ".format(
+                                  verify_arb_id), end=" ")
+                            tp.transmit(session_control_frames,
+                                        verify_arb_id, None)
+                            # Give some extra time for verification, in
+                            # case of slow responses
+                            verification_end_time = time.time()
+                            + delay + VERIFICATION_EXTRA_DELAY
                             while time.time() < verification_end_time:
                                 verification_msg = tp.bus.recv(0)
                                 if verification_msg is None:
@@ -204,12 +229,16 @@ def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay
                                 if is_valid_response(verification_msg):
                                     # Verified
                                     verified = True
-                                    # Update send ID - if server responds slowly, the initial value may be faulty.
-                                    # It also ensures we resume searching on the next arbitration ID after the actual
-                                    # match, rather than the one after the last potential match (which could lead to
-                                    # false negatives if multiple servers listen to adjacent arbitration IDs and respond
-                                    # slowly)
-                                    send_arbitration_id = verification_arbitration_id
+                                    # Update send ID - if server responds
+                                    # slowly, initial value may be faulty.
+                                    # Also ensures we resume searching on
+                                    # the next arb ID after the actual
+                                    # match, rather than the one after the
+                                    # last potential match (which could lead
+                                    # to false negatives if multiple servers
+                                    # listen to adjacent arbitration IDs and
+                                    # respond slowly)
+                                    send_arb_id = verify_arb_id
                                     break
                             if print_results:
                                 # Print result
@@ -231,10 +260,12 @@ def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration, delay
                         if not verify:
                             # Blank line needed
                             print()
-                        print("Found diagnostics server listening at 0x{0:04x}, response at 0x{1:04x}".format(
-                            send_arbitration_id, msg.arbitration_id))
+                        print("Found diagnostics server listening at "
+                              "0x{0:04x}, response at 0x{1:04x}".format(
+                                send_arb_id, msg.arbitration_id))
                     # Add found arbitration ID pair
-                    found_arb_id_pair = (send_arbitration_id, msg.arbitration_id)
+                    found_arb_id_pair = (send_arb_id,
+                                         msg.arbitration_id)
                     found_arbitration_ids.append(found_arb_id_pair)
         if print_results:
             print()
@@ -252,7 +283,9 @@ def __uds_discovery_wrapper(args):
     print_results = True
 
     try:
-        arb_id_pairs = uds_discovery(min_id, max_id, blacklist, auto_blacklist_duration, delay, verify, print_results)
+        arb_id_pairs = uds_discovery(min_id, max_id, blacklist,
+                                     auto_blacklist_duration,
+                                     delay, verify, print_results)
         if len(arb_id_pairs) == 0:
             # No UDS discovered
             print("\nDiagnostics service could not be found.")
@@ -264,15 +297,17 @@ def __uds_discovery_wrapper(args):
             print("| CLIENT ID  | SERVER ID  |")
             print(table_line)
             for (client_id, server_id) in arb_id_pairs:
-                print("| 0x{0:08x} | 0x{1:08x} |".format(client_id, server_id))
+                print("| 0x{0:08x} | 0x{1:08x} |".format(
+                  client_id, server_id))
             print(table_line)
     except ValueError as e:
         print("Discovery failed: {0}".format(e))
 
 
-def service_discovery(arb_id_request, arb_id_response, timeout, min_id=BYTE_MIN, max_id=BYTE_MAX,
-                      print_results=True):
-    """Scans for supported UDS services on the specified arbitration ID. Returns a list of found service IDs.
+def service_discovery(arb_id_request, arb_id_response, timeout,
+                      min_id=BYTE_MIN, max_id=BYTE_MAX, print_results=True):
+    """Scans for supported UDS services on the specified arbitration ID.
+       Returns a list of found service IDs.
 
     :param arb_id_request: arbitration ID for requests
     :param arb_id_response: arbitration ID for responses
@@ -291,7 +326,8 @@ def service_discovery(arb_id_request, arb_id_response, timeout, min_id=BYTE_MIN,
     """
     found_services = []
 
-    with IsoTp(arb_id_request=arb_id_request, arb_id_response=arb_id_response) as tp:
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
         # Setup filter for incoming messages
         tp.set_filter_single_arbitration_id(arb_id_response)
         # Send requests
@@ -299,8 +335,9 @@ def service_discovery(arb_id_request, arb_id_response, timeout, min_id=BYTE_MIN,
             for service_id in range(min_id, max_id + 1):
                 tp.send_request([service_id])
                 if print_results:
-                    print("\rProbing service 0x{0:02x} ({0}/{1}): found {2}".format(
-                        service_id, max_id, len(found_services)), end="")
+                    print("\rProbing service 0x{0:02x} ({0}/{1}): found {2}"
+                          .format(service_id, max_id, len(found_services)),
+                          end="")
                 stdout.flush()
                 # Get response
                 msg = tp.bus.recv(timeout)
@@ -309,11 +346,14 @@ def service_discovery(arb_id_request, arb_id_response, timeout, min_id=BYTE_MIN,
                     continue
                 # Parse response
                 if len(msg.data) > 3:
-                    # Since service ID is included in the response, mapping is correct even if response is delayed
+                    # Since service ID is included in the response, mapping
+                    # is correct even if response is delayed
                     service_id = msg.data[2]
                     status = msg.data[3]
-                    if status != NegativeResponseCodes.SERVICE_NOT_SUPPORTED:
-                        # Any other response than "service not supported" counts
+                    if(status !=
+                       NegativeResponseCodes.SERVICE_NOT_SUPPORTED):
+                        # Any other response than "service not supported"
+                        # counts
                         found_services.append(service_id)
             if print_results:
                 print("\nDone!\n")
@@ -329,41 +369,50 @@ def __service_discovery_wrapper(args):
     arb_id_response = args.dst
     timeout = args.timeout
     # Probe services
-    found_services = service_discovery(arb_id_request, arb_id_response, timeout)
+    found_services = service_discovery(arb_id_request,
+                                       arb_id_response, timeout)
     # Print results
     for service_id in found_services:
         service_name = UDS_SERVICE_NAMES.get(service_id, "Unknown service")
-        print("Supported service 0x{0:02x}: {1}".format(service_id, service_name))
+        print("Supported service 0x{0:02x}: {1}"
+              .format(service_id, service_name))
 
 
-def tester_present(arb_id_request, delay, duration, suppress_positive_response):
+def tester_present(arb_id_request, delay, duration,
+                   suppress_positive_response):
     """Sends TesterPresent messages to 'arb_id_request'. Stops automatically
     after 'duration' seconds or runs forever if this is None.
 
     :param arb_id_request: arbitration ID for requests
     :param delay: seconds between each request
-    :param duration: seconds before automatically stopping, or None to continue forever
-    :param suppress_positive_response: whether positive responses should be suppressed
+    :param duration: seconds before automatically stopping, or None to
+                     continue forever
+    :param suppress_positive_response: whether positive responses should
+                                       be suppressed
     :type arb_id_request: int
     :type delay: float
     :type duration: float or None
     :type suppress_positive_response: bool
     """
-    # SPR simply tells the recipient not to send a positive response to each TesterPresent message
+    # SPR simply tells the recipient not to send a positive response to
+    # each TesterPresent message
     if suppress_positive_response:
         sub_function = 0x80
     else:
         sub_function = 0x00
 
-    # Calculate end timestamp if the TesterPresent should automatically stop after a given duration
+    # Calculate end timestamp if the TesterPresent should automatically
+    # stop after a given duration
     auto_stop = duration is not None
     end_time = None
     if auto_stop:
-        end_time = datetime.datetime.now() + datetime.timedelta(seconds=duration)
+        end_time = datetime.datetime.now()
+        + datetime.timedelta(seconds=duration)
 
     service_id = Services.TesterPresent.service_id
     message_data = [service_id, sub_function]
-    print("Sending TesterPresent to arbitration ID {0} (0x{0:02x})".format(arb_id_request))
+    print("Sending TesterPresent to arbitration ID {0} (0x{0:02x})"
+          .format(arb_id_request))
     print("\nPress Ctrl+C to stop\n")
     with IsoTp(arb_id_request, None) as can_wrap:
         counter = 1
@@ -384,17 +433,20 @@ def __tester_present_wrapper(args):
     duration = args.duration
     suppress_positive_response = args.spr
 
-    tester_present(arb_id_request, delay, duration, suppress_positive_response)
+    tester_present(arb_id_request, delay, duration,
+                   suppress_positive_response)
 
 
 def ecu_reset(arb_id_request, arb_id_response, reset_type, timeout):
-    """Sends an ECU Reset message to 'arb_id_request'. Returns the first response
-    received from 'arb_id_response' within 'timeout' seconds or None otherwise.
+    """Sends an ECU Reset message to 'arb_id_request'. Returns the first
+        response received from 'arb_id_response' within 'timeout' seconds
+        or None otherwise.
 
     :param arb_id_request: arbitration ID for requests
     :param arb_id_response: arbitration ID for responses
     :param reset_type: value corresponding to a reset type
-    :param timeout: seconds to wait for response before timeout, or None for default UDS timeout
+    :param timeout: seconds to wait for response before timeout, or None
+                    for default UDS timeout
     :type arb_id_request: int
     :type arb_id_response int
     :type reset_type: int
@@ -404,11 +456,14 @@ def ecu_reset(arb_id_request, arb_id_response, reset_type, timeout):
     """
     # Sanity checks
     if not BYTE_MIN <= reset_type <= BYTE_MAX:
-        raise ValueError("reset type must be within interval 0x{0:02x}-0x{1:02x}".format(BYTE_MIN, BYTE_MAX))
+        raise ValueError("reset type must be within interval "
+                         "0x{0:02x}-0x{1:02x}".format(BYTE_MIN, BYTE_MAX))
     if isinstance(timeout, float) and timeout < 0.0:
-        raise ValueError("timeout value ({0}) cannot be negative".format(timeout))
+        raise ValueError("timeout value ({0}) cannot be negative"
+                         .format(timeout))
 
-    with IsoTp(arb_id_request=arb_id_request, arb_id_response=arb_id_response) as tp:
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
         # Setup filter for incoming messages
         tp.set_filter_single_arbitration_id(arb_id_response)
         with Iso14229_1(tp) as uds:
@@ -427,9 +482,11 @@ def __ecu_reset_wrapper(args):
     reset_type = args.reset_type
     timeout = args.timeout
 
-    print("Sending ECU reset, type 0x{0:02x} to arbitration ID {1} (0x{1:02x})".format(reset_type, arb_id_request))
+    print("Sending ECU reset, type 0x{0:02x} to arbitration ID {1} "
+          "(0x{1:02x})".format(reset_type, arb_id_request))
     try:
-        response = ecu_reset(arb_id_request, arb_id_response, reset_type, timeout)
+        response = ecu_reset(arb_id_request, arb_id_response,
+                             reset_type, timeout)
     except ValueError as e:
         print("ValueError: {0}".format(e))
         return
@@ -444,30 +501,38 @@ def __ecu_reset_wrapper(args):
             print("Received empty response")
         elif response_length == 1:
             # Invalid response length
-            print("Received response [{0:02x}] (1 byte), expected at least 2 bytes".format(response[0], len(response)))
+            print("Received response [{0:02x}] (1 byte), expected at least "
+                  " 2 bytes".format(response[0], len(response)))
         elif Iso14229_1.is_positive_response(response):
             # Positive response handling
             response_service_id = response[0]
             subfunction = response[1]
-            expected_response_id = Iso14229_1.get_service_response_id(Services.EcuReset.service_id)
-            if response_service_id == expected_response_id and subfunction == reset_type:
+            expected_response_id = \
+                Iso14229_1.get_service_response_id(
+                                               Services.EcuReset.service_id)
+            if(response_service_id == expected_response_id
+               and subfunction == reset_type):
                 # Positive response
                 pos_msg = "Received positive response"
                 if response_length > 2:
-                    # Additional data can be seconds left to reset (powerDownTime) or manufacturer specific
+                    # Additional data can be seconds left to reset
+                    # (powerDownTime) or manufacturer specific
                     additional_data = list_to_hex_str(response[2:], ",")
-                    pos_msg += " with additional data: [{0}]".format(
-                                                            additional_data)
+                    pos_msg += " with additional data: [{0}]"\
+                               .format(additional_data)
                 print(pos_msg)
             else:
                 # Service and/or subfunction mismatch
                 print("Response service ID 0x{0:02x} and subfunction "
-                    "0x{1:02x} do not match expected values 0x{2:02x} "
-                    "and 0x{3:02x}".format(response_service_id,
-                    subfunction, Services.EcuReset.service_id, reset_type))
+                      "0x{1:02x} do not match expected values 0x{2:02x} "
+                      "and 0x{3:02x}".format(response_service_id,
+                                             subfunction,
+                                             Services.EcuReset.service_id,
+                                             reset_type))
         else:
             # Negative response handling
             print_negative_response(response)
+
 
 def print_negative_response(response):
     """
@@ -482,7 +547,8 @@ def print_negative_response(response):
     nrc = response[2]
     nrc_description = NRC_NAMES.get(nrc, "Unknown NRC value")
     print("Received negative response code (NRC) 0x{0:02x}: {1}"
-                .format(nrc, nrc_description))
+          .format(nrc, nrc_description))
+
 
 def __security_seed_wrapper(args):
     """Wrapper used to initiate secuirty seed dump"""
@@ -496,23 +562,25 @@ def __security_seed_wrapper(args):
     seed_list = []
     try:
         print("Security Seed dump started. To end, use Ctrl+C and a report "
-                "will be output to stdout.\n")
+              "will be output to stdout.\n")
         while num_seeds > len(seed_list) or num_seeds == 0:
-            #Extended diagnostics
-            response = extended_session(arb_id_request, arb_id_response,
-                                                                session_type)
+            # Extended diagnostics
+            response = extended_session(arb_id_request,
+                                        arb_id_response,
+                                        session_type)
             if response is None:
-                #simple retry in-case bus wasn't awake for first request
-                response = extended_session(arb_id_request, arb_id_response,
-                                                                session_type)
-            #Request seed
+                # Simple retry in-case bus wasn't awake for first request
+                response = extended_session(arb_id_request,
+                                            arb_id_response,
+                                            session_type)
+            # Request seed
             response = request_seed(arb_id_request, arb_id_response,
-                            level, None, None)
+                                    level, None, None)
             if Iso14229_1.is_positive_response(response):
                 seed_list.append(list_to_hex_str(response[2:]))
                 print("Seed received: {}\t(Total captured: {})"
-                        .format(list_to_hex_str(response[2:]),
-                        len(seed_list)), end="\r")
+                      .format(list_to_hex_str(response[2:]),
+                              len(seed_list)), end="\r")
                 stdout.flush()
             else:
                 print_negative_response(response)
@@ -534,27 +602,37 @@ def __security_seed_wrapper(args):
         for seed in seed_list:
             print(seed)
 
+
 def extended_session(arb_id_request, arb_id_response, session_type):
     # Sanity checks
-    if not Services.DiagnosticSessionControl.DiagnosticSessionType().is_valid_session(session_type):
-        raise ValueError("Invalid extended session type: 0x{0:02x}".format(session_type))
+    if(not Services.DiagnosticSessionControl.DiagnosticSessionType()
+       .is_valid_session(session_type)):
+        raise ValueError("Invalid extended session type: 0x{0:02x}"
+                         .format(session_type))
 
-    with IsoTp(arb_id_request=arb_id_request, arb_id_response=arb_id_response) as tp:
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
         # Setup filter for incoming messages
         tp.set_filter_single_arbitration_id(arb_id_response)
         with Iso14229_1(tp) as uds:
             response = uds.diagnostic_session_control(session_type)
             return response
 
-def request_seed(arb_id_request, arb_id_response, level, data_record, timeout):
-    """Sends an Request seed message to 'arb_id_request'. Returns the first response
-    received from 'arb_id_response' within 'timeout' seconds or None otherwise.
+
+def request_seed(arb_id_request, arb_id_response, level,
+                 data_record, timeout):
+    """Sends an Request seed message to 'arb_id_request'. Returns the
+       first response received from 'arb_id_response' within 'timeout'
+       seconds or None otherwise.
 
     :param arb_id_request: arbitration ID for requests
     :param arb_id_response: arbitration ID for responses
-    :param level: vehicle manufacturer specific access level to request seed for
-    :param data_record: optional vehicle manufacturer specific data to transmit when requesting seed
-    :param timeout: seconds to wait for response before timeout, or None for default UDS timeout
+    :param level: vehicle manufacturer specific access level to request
+                  seed for
+    :param data_record: optional vehicle manufacturer specific data to
+                        transmit when requesting seed
+    :param timeout: seconds to wait for response before timeout, or None
+                    for default UDS timeout
     :type arb_id_request: int
     :type arb_id_response: int
     :type level: int
@@ -564,12 +642,15 @@ def request_seed(arb_id_request, arb_id_response, level, data_record, timeout):
     :rtype [int] or None
     """
     # Sanity checks
-    if not Services.SecurityAccess.RequestSeedOrSendKey().is_valid_request_seed_level(level):
+    if(not Services.SecurityAccess.RequestSeedOrSendKey()
+       .is_valid_request_seed_level(level)):
         raise ValueError("Invalid request seed level")
     if isinstance(timeout, float) and timeout < 0.0:
-        raise ValueError("timeout value ({0}) cannot be negative".format(timeout))
+        raise ValueError("timeout value ({0}) cannot be negative"
+                         .format(timeout))
 
-    with IsoTp(arb_id_request=arb_id_request, arb_id_response=arb_id_response) as tp:
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
         # Setup filter for incoming messages
         tp.set_filter_single_arbitration_id(arb_id_response)
         with Iso14229_1(tp) as uds:
@@ -583,14 +664,16 @@ def request_seed(arb_id_request, arb_id_response, level, data_record, timeout):
 
 def send_key(arb_id_request, arb_id_response, level, key, timeout):
     """
-    Sends an Send key message to 'arb_id_request'. Returns the first response
-    received from 'arb_id_response' within 'timeout' seconds or None otherwise.
+    Sends an Send key message to 'arb_id_request'.
+    Returns the first response received from 'arb_id_response' within
+    'timeout' seconds or None otherwise.
 
     :param arb_id_request: arbitration ID for requests
     :param arb_id_response: arbitration ID for responses
     :param level: vehicle manufacturer specific access level to send key for
     :param key: key to transmit
-    :param timeout: seconds to wait for response before timeout, or None for default UDS timeout
+    :param timeout: seconds to wait for response before timeout, or None
+                    for default UDS timeout
     :type arb_id_request: int
     :type arb_id_response: int
     :type level: int
@@ -600,12 +683,15 @@ def send_key(arb_id_request, arb_id_response, level, key, timeout):
     :rtype [int] or None
     """
     # Sanity checks
-    if not Services.SecurityAccess.RequestSeedOrSendKey().is_valid_send_key_level(level):
+    if(not Services.SecurityAccess.RequestSeedOrSendKey()
+       .is_valid_send_key_level(level)):
         raise ValueError("Invalid send key level")
     if isinstance(timeout, float) and timeout < 0.0:
-        raise ValueError("timeout value ({0}) cannot be negative".format(timeout))
+        raise ValueError("timeout value ({0}) cannot be negative"
+                         .format(timeout))
 
-    with IsoTp(arb_id_request=arb_id_request, arb_id_response=arb_id_response) as tp:
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
         # Setup filter for incoming messages
         tp.set_filter_single_arbitration_id(arb_id_response)
         with Iso14229_1(tp) as uds:
@@ -619,93 +705,139 @@ def send_key(arb_id_request, arb_id_response, level, key, timeout):
 
 def __parse_args(args):
     """Parser for module arguments"""
-    parser = argparse.ArgumentParser(prog="cc.py uds",
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     description="""Universal Diagnostic Services module for CaringCaribou""",
-                                     epilog="""Example usage:
-  cc.py uds discovery
-  cc.py uds discovery -blacklist 0x123 0x456
-  cc.py uds discovery -autoblacklist 10
-  cc.py uds services 0x733 0x633
-  cc.py uds ecu_reset 1 0x733 0x633
-  cc.py uds testerpresent 0x733
-  cc.py uds security_seed 0x3 0x1 0x733 0x633 -r 1""")
+    parser = argparse.ArgumentParser(
+                prog="cc.py uds",
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+                description="Universal Diagnostic Services module for"
+                "CaringCaribou",
+                epilog="""Example usage:
+                cc.py uds discovery
+                cc.py uds discovery -blacklist 0x123 0x456
+                cc.py uds discovery -autoblacklist 10
+                cc.py uds services 0x733 0x633
+                cc.py uds ecu_reset 1 0x733 0x633
+                cc.py uds testerpresent 0x733
+                cc.py uds security_seed 0x3 0x1 0x733 0x633 -r 1""")
     subparsers = parser.add_subparsers(dest="module_function")
     subparsers.required = True
 
     # Parser for diagnostics discovery
     parser_discovery = subparsers.add_parser("discovery")
-    parser_discovery.add_argument("-min", type=parse_int_dec_or_hex, default=None,
-                                  help="min arbitration ID to send request for")
-    parser_discovery.add_argument("-max", type=parse_int_dec_or_hex, default=None,
-                                  help="max arbitration ID to send request for")
-    parser_discovery.add_argument("-b", "--blacklist", metavar="B", type=parse_int_dec_or_hex, default=[], nargs="+",
-                                  help="arbitration IDs to blacklist responses from")
-    parser_discovery.add_argument("-ab", "--autoblacklist", metavar="N", type=float, default=0,
-                                  help="listen for false positives for N seconds and blacklist matching "
-                                       "arbitration IDs before running discovery")
-    parser_discovery.add_argument("-sv", "--skipverify", action="store_true",
-                                  help="skip verification step (reduces result accuracy)")
-    parser_discovery.add_argument("-d", "--delay", metavar="D", type=float, default=DELAY_DISCOVERY,
-                                  help="D seconds delay between messages (default: {0})".format(DELAY_DISCOVERY))
+    parser_discovery.add_argument("-min",
+                                  type=parse_int_dec_or_hex, default=None,
+                                  help="min arbitration ID to send request "
+                                  "for")
+    parser_discovery.add_argument("-max",
+                                  type=parse_int_dec_or_hex, default=None,
+                                  help="max arbitration ID to send request "
+                                  "for")
+    parser_discovery.add_argument("-b", "--blacklist", metavar="B",
+                                  type=parse_int_dec_or_hex, default=[],
+                                  nargs="+",
+                                  help="arbitration IDs to blacklist "
+                                  "responses from")
+    parser_discovery.add_argument("-ab", "--autoblacklist", metavar="N",
+                                  type=float, default=0,
+                                  help="listen for false positives for N "
+                                  "seconds and blacklist matching "
+                                  "arbitration IDs before running discovery"
+                                  )
+    parser_discovery.add_argument("-sv", "--skipverify",
+                                  action="store_true",
+                                  help="skip verification step (reduces "
+                                  "result accuracy)")
+    parser_discovery.add_argument("-d", "--delay", metavar="D",
+                                  type=float, default=DELAY_DISCOVERY,
+                                  help="D seconds delay between messages "
+                                  "(default: {0})".format(DELAY_DISCOVERY))
     parser_discovery.set_defaults(func=__uds_discovery_wrapper)
 
     # Parser for diagnostics service discovery
     parser_info = subparsers.add_parser("services")
-    parser_info.add_argument("src", type=parse_int_dec_or_hex, help="arbitration ID to transmit to")
-    parser_info.add_argument("dst", type=parse_int_dec_or_hex, help="arbitration ID to listen to")
-    parser_info.add_argument("-t", "--timeout", metavar="T", type=float, default=TIMEOUT_SERVICES,
-                             help="wait T seconds for response before timeout (default: {0})".format(TIMEOUT_SERVICES))
+    parser_info.add_argument("src",
+                             type=parse_int_dec_or_hex,
+                             help="arbitration ID to transmit to")
+    parser_info.add_argument("dst",
+                             type=parse_int_dec_or_hex,
+                             help="arbitration ID to listen to")
+    parser_info.add_argument("-t", "--timeout", metavar="T",
+                             type=float, default=TIMEOUT_SERVICES,
+                             help="wait T seconds for response before "
+                             "timeout (default: {0})"
+                             .format(TIMEOUT_SERVICES))
     parser_info.set_defaults(func=__service_discovery_wrapper)
 
     # Parser for ECU Reset
     parser_ecu_reset = subparsers.add_parser("ecu_reset")
-    parser_ecu_reset.add_argument("reset_type", metavar="type", type=parse_int_dec_or_hex,
-                                  help="Reset type: 1=hard, 2=key off/on, 3=soft, "
-                                    "4=enable rapid power shutdown, 5=disable rapid power shutdown")
-    parser_ecu_reset.add_argument("src", type=parse_int_dec_or_hex, help="arbitration ID to transmit to")
-    parser_ecu_reset.add_argument("dst", type=parse_int_dec_or_hex, help="arbitration ID to listen to")
-    parser_ecu_reset.add_argument("-t", "--timeout", type=float, metavar="T",
-                                  help="wait T seconds for response before timeout")
+    parser_ecu_reset.add_argument("reset_type", metavar="type",
+                                  type=parse_int_dec_or_hex,
+                                  help="Reset type: 1=hard, 2=key off/on,"
+                                  " 3=soft, 4=enable rapid power shutdown,"
+                                  " 5=disable rapid power shutdown")
+    parser_ecu_reset.add_argument("src",
+                                  type=parse_int_dec_or_hex,
+                                  help="arbitration ID to transmit to")
+    parser_ecu_reset.add_argument("dst",
+                                  type=parse_int_dec_or_hex,
+                                  help="arbitration ID to listen to")
+    parser_ecu_reset.add_argument("-t", "--timeout",
+                                  type=float, metavar="T",
+                                  help="wait T seconds for response before "
+                                  "timeout")
     parser_ecu_reset.set_defaults(func=__ecu_reset_wrapper)
 
     # Parser for TesterPresent
     parser_tp = subparsers.add_parser("testerpresent")
-    parser_tp.add_argument("src", type=parse_int_dec_or_hex, help="arbitration ID to transmit to")
-    parser_tp.add_argument("-d", "--delay", metavar="D", type=float, default=DELAY_TESTER_PRESENT,
-                           help="send TesterPresent every D seconds (default: {0})".format(DELAY_TESTER_PRESENT))
-    parser_tp.add_argument("-dur", "--duration", metavar="S", type=float, help="automatically stop after S seconds")
-    parser_tp.add_argument("-spr", action="store_true", help="suppress positive response")
+    parser_tp.add_argument("src",
+                           type=parse_int_dec_or_hex,
+                           help="arbitration ID to transmit to")
+    parser_tp.add_argument("-d", "--delay", metavar="D",
+                           type=float, default=DELAY_TESTER_PRESENT,
+                           help="send TesterPresent every D seconds "
+                           "(default: {0})".format(DELAY_TESTER_PRESENT))
+    parser_tp.add_argument("-dur", "--duration", metavar="S",
+                           type=float,
+                           help="automatically stop after S seconds")
+    parser_tp.add_argument("-spr", action="store_true",
+                           help="suppress positive response")
     parser_tp.set_defaults(func=__tester_present_wrapper)
-
 
     # Parser for SecuritySeedDump
     parser_secseed = subparsers.add_parser("security_seed")
     parser_secseed.add_argument("sess_type", metavar="stype",
-            type=parse_int_dec_or_hex, help="Session Type: 1=defaultSession "
-            "2=programmingSession 3=extendedSession 4=safetySession [0x40"
-            "-0x5F]=OEM [0x60-0x7E]=Supplier [0x0, 0x5-0x3F, 0x7F]=ISOSAE"
-            "Reserved")
+                                type=parse_int_dec_or_hex,
+                                help="Session Type: 1=defaultSession "
+                                "2=programmingSession 3=extendedSession "
+                                "4=safetySession [0x40-0x5F]=OEM "
+                                "[0x60-0x7E]=Supplier "
+                                "[0x0, 0x5-0x3F, 0x7F]=ISOSAEReserved")
     parser_secseed.add_argument("sec_level", metavar="level",
-            type=parse_int_dec_or_hex, help="Security level: [0x1 - 0x41"
-            " (odd only)]=OEM 0x5F=EOLPyrotechnics [0x61-0x7E]=Supplier "
-            "[0x0, 0x43-0x5E, 0x7F]=ISOSAEReserved")
-    parser_secseed.add_argument("src", type=parse_int_dec_or_hex,
-            help="arbitration ID to transmit to")
-    parser_secseed.add_argument("dst", type=parse_int_dec_or_hex,
-            help="arbitration ID to listen to")
+                                type=parse_int_dec_or_hex,
+                                help="Security level: "
+                                "[0x1-0x41 (odd only)]=OEM "
+                                "0x5F=EOLPyrotechnics "
+                                "[0x61-0x7E]=Supplier "
+                                "[0x0, 0x43-0x5E, 0x7F]=ISOSAEReserved")
+    parser_secseed.add_argument("src",
+                                type=parse_int_dec_or_hex,
+                                help="arbitration ID to transmit to")
+    parser_secseed.add_argument("dst",
+                                type=parse_int_dec_or_hex,
+                                help="arbitration ID to listen to")
     parser_secseed.add_argument("-r", "--reset", metavar="rtype",
-            type=parse_int_dec_or_hex, help="Enable reset between security "
-            "seed requests. Reset type: 1=hardReset, 2=key off/on, "
-            "3=softReset, 4=enable rapid power shutdown, 5=disable rapid "
-            "power shutdown")
+                                type=parse_int_dec_or_hex,
+                                help="Enable reset between security "
+                                "seed requests. Reset type: 1=hardReset, "
+                                "2=key off/on, 3=softReset, 4=enable rapid "
+                                "power shutdown, 5=disable rapid "
+                                "power shutdown")
     parser_secseed.add_argument("-n", "--num", metavar="NUM", default=0,
-            type=parse_int_dec_or_hex, help="Specify a positive number of " 
-            "security seeds to capture before terminating. A '0' is "
-            "interpreted as infinity. (default: 0)")
+                                type=parse_int_dec_or_hex,
+                                help="Specify a positive number of security"
+                                " seeds to capture before terminating. "
+                                "A '0' is interpreted as infinity. "
+                                "(default: 0)")
     parser_secseed.set_defaults(func=__security_seed_wrapper)
-
-
 
     args = parser.parse_args(args)
     return args

--- a/tool/tests/test_send.py
+++ b/tool/tests/test_send.py
@@ -42,4 +42,3 @@ class SendFileParserTestCase(unittest.TestCase):
         line = "Timestamp:        0.000000    ID: 00000000    X   R            DLC:  4    de ad ca fe"
         message, timestamp = send.parse_pythoncan_line(line, None, None)
         self.assertListEqual(message.data, self.RESULT_DATA_DEAD_CAFE)
-


### PR DESCRIPTION
Added new security_seed functionality to UDS module. This function asks the UDS server for a Security Access seed repeatedly and records every seed received.
It can be used to analyze the randomness of the UDS server's Security Access seed.
Supported options include different "Security Access levels", different "Diagnostic Sessions", and performing different types of "ECU Resets" between seed requests.
Results are printed to stdout.

![image](https://user-images.githubusercontent.com/5995272/55983443-2a268600-5c69-11e9-926c-5ee150688a62.png)

![image](https://user-images.githubusercontent.com/5995272/55989086-7ecefe80-5c73-11e9-8649-9daa09a5d0a3.png)
