### PR TITLE
Clarify that the -i flag forces SocketCAN bustype

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Implementation of the ISO-14229-1 standard for Unified Diagnostic Services (UDS)
 Implementation of the ISO-15765-2 standard (ISO-TP). This is a transport protocol which enables sending of messages longer than 8 bytes over CAN by splitting them into multiple data frames.
 
 ## Hardware requirements
-Some sort of CAN bus interface compatible with socketCAN (http://elinux.org/CAN_Bus#CAN_Support_in_Linux)
+Some sort of CAN bus interface compatible with socketCAN (http://elinux.org/CAN_Bus#CAN_Support_in_Linux) or directly supported by python-can (https://python-can.readthedocs.io/en/3.1.1/interfaces.html).
 
 ## Software requirements
 - Python 2.7 or 3.x

--- a/documentation/howtouse.md
+++ b/documentation/howtouse.md
@@ -31,7 +31,7 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
-  -i INTERFACE  force interface, e.g. 'can1' or 'vcan0'
+  -i INTERFACE  force SocketCAN interface, e.g. 'can1' or 'vcan0'
 
 available modules:
   dcm, dump, fuzzer, listener, send, test, xcp
@@ -94,21 +94,22 @@ optional arguments:
   --loop, -l       loop message sequence (re-send over and over)
 ```
 
-### Non-default interface
-In order to use a non-default CAN interface for any module, you can always provide the `-i INTERFACE` flag before the module name.
+### Non-default interface with SocketCAN
+In order to use a non-default SocketCAN interface for any module, you can always provide the `-i INTERFACE` flag before the module name. This forces the bustype to SocketCAN and channel to `INTERFACE` overriding the user configuration of `bustype` and `channel` for python-can.
 
-For instance, in oder to send the message `c0 ff ee` with arbitration ID `0xf00` on virtual CAN bus `vcan0`, you would run
+For instance, in oder to send the message `c0 ff ee` with arbitration ID `0xf00` on a SocketCAN virtual CAN bus `vcan0`, you would run
 
     $ ./cc.py -i vcan0 send message 0xf00#c0.ff.ee
 
 More information on the different modules is available here:
-+ [dcm-module](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/dcm.md)
++ [uds-module](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/uds.md)
++ [dcm-module (deprecated)](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/dcm.md)
 + [xcp-module](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/xcp.md)
 + [send-module](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/send.md)
 + [listener-module](https://github.com/CaringCaribou/caringcaribou/blob/master/documentation/listener.md)
 
-### Virtual CAN bus
-In order to communicate over CAN without access to a physical CAN bus, it is possible to use a virtual CAN bus instead. Doing this in Linux is generally as easy as running the following commands:
+### SocketCAN Virtual CAN bus
+In order to communicate over CAN without access to a physical CAN bus, it is possible to use a SocketCAN virtual CAN bus instead. Doing this in Linux is generally as easy as running the following commands:
 
     sudo modprobe vcan
     sudo ip link add dev vcan0 type vcan

--- a/tool/cc.py
+++ b/tool/cc.py
@@ -69,7 +69,7 @@ def parse_arguments():
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      epilog=available_modules())
     parser.add_argument("-i", dest="interface", default=None,
-                        help="force interface, e.g. 'can1' or 'vcan0'")
+                        help="force SocketCAN interface, e.g. 'can1' or 'vcan0'")
     parser.add_argument("module",
                         help="Name of the module to run")
     parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,

--- a/tool/lib/can_actions.py
+++ b/tool/lib/can_actions.py
@@ -14,7 +14,7 @@ DELAY_STEP = 0.02
 NOTIFIER_STOP_DURATION = 0.5
 
 # Global CAN interface setting, which can be set through the -i flag to cc.py
-# The value None corresponds to the default CAN interface (typically can0)
+# The value None corresponds to the CAN interface configured through python-can
 DEFAULT_INTERFACE = None
 
 
@@ -75,7 +75,10 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+        if DEFAULT_INTERFACE is not None:
+            self.bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+        else:
+            self.bus = can.Bus()
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -38,7 +38,10 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+            if DEFAULT_INTERFACE is not None:
+                self.bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+            else:
+                self.bus = can.Bus()
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request


### PR DESCRIPTION
Clarification in documentation and cc.py help message.
Also fixes can.Bus() python-can API usage in can_actions and iso15765_2 to conform to generic API requirements. If an interface is provided with -i, set bustype to socketcan, and when no interface is provided with -i, use default python-can configs.
