### PR TITLE
Interface agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Implementation of the ISO-14229-1 standard for Unified Diagnostic Services (UDS)
 Implementation of the ISO-15765-2 standard (ISO-TP). This is a transport protocol which enables sending of messages longer than 8 bytes over CAN by splitting them into multiple data frames.
 
 ## Hardware requirements
-Some sort of CAN bus interface compatible with socketCAN (http://elinux.org/CAN_Bus#CAN_Support_in_Linux)
+Some sort of CAN bus interface (http://elinux.org/CAN_Bus#CAN_Support_in_Linux)
 
 ## Software requirements
 - Python 2.7 or 3.x

--- a/documentation/howtoinstall.md
+++ b/documentation/howtoinstall.md
@@ -42,14 +42,11 @@ Tested with python-can 1.5.2 and 2.0.0a2.
 
 ##### Configure
 Python-Can uses a configuration file ```~/.canrc``` to specify a CAN interface.
-The contents of this file should be:
+The contents of this file might e.g. be:
 
     [default]
     interface = socketcan
     channel = can0
-
-*Note:* In case you are running an ancient version of python-can (from 2015-ish), you may need to set the interface to
-`socketcan_ctypes` instead.
 
 ##### Test it
 Go to the Caring Caribou directory and run the following command:

--- a/tool/lib/can_actions.py
+++ b/tool/lib/can_actions.py
@@ -75,7 +75,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+        self.bus = can.Bus(DEFAULT_INTERFACE)
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -38,7 +38,7 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE, "socketcan")
+            self.bus = can.Bus(DEFAULT_INTERFACE)
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request

--- a/tool/tests/mock/mock_ecu.py
+++ b/tool/tests/mock/mock_ecu.py
@@ -11,7 +11,7 @@ class MockEcu:
     def __init__(self, bus=None):
         self.message_process = None
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+            self.bus = can.Bus(DEFAULT_INTERFACE)
         else:
             self.bus = bus
 

--- a/tool/tests/test_iso_14229_1.py
+++ b/tool/tests/test_iso_14229_1.py
@@ -17,7 +17,7 @@ class DiagnosticsOverIsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIso14229(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+        can_bus = can.Bus(DEFAULT_INTERFACE)
         # Setup diagnostics on top of ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
         self.diagnostics = iso14229_1.Iso14229_1(self.tp)

--- a/tool/tests/test_iso_15765_2.py
+++ b/tool/tests/test_iso_15765_2.py
@@ -16,7 +16,7 @@ class IsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE, bustype="socketcan")
+        can_bus = can.Bus(DEFAULT_INTERFACE)
         # Setup ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
 


### PR DESCRIPTION
Replace both redundant and hardcoded (socketcan) interface type arguments with fallback to python-can configuration file.

See discussion in https://github.com/CaringCaribou/caringcaribou/issues/52