### PR TITLE
adding pattern of positive response in uds service_discovery

### DIFF
--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -310,11 +310,14 @@ def service_discovery(arb_id_request, arb_id_response, timeout, min_id=BYTE_MIN,
                 # Parse response
                 if len(msg.data) > 3:
                     # Since service ID is included in the response, mapping is correct even if response is delayed
-                    service_id = msg.data[2]
+                    response_id = msg.data[1]
+                    response_service_id = msg.data[2]
                     status = msg.data[3]
-                    if status != NegativeResponseCodes.SERVICE_NOT_SUPPORTED:
+                    if response_id != 0x7F:
+                        found_services.append(response_id - 0x40)
+                    elif status != NegativeResponseCodes.SERVICE_NOT_SUPPORTED:
                         # Any other response than "service not supported" counts
-                        found_services.append(service_id)
+                        found_services.append(response_service_id)
             if print_results:
                 print("\nDone!\n")
         except KeyboardInterrupt:


### PR DESCRIPTION
Currently, service_discovery expects only when the ECU response is Negative Response.  
If a Positive Response is returned, the value of msg.data [2] will be the value of Response Data or Padding.

"Toyota Prius C" responds to TesterPresents as follows (output of candump):
```
  can0 TX - - 7E0 [8] 01 3E 00 00 00 00 00 00 '.> ......'
  can0 RX - - 7E8 [8] 01 7E 00 00 00 00 00 00 '. ~ ......'
```

At this time, the value of msg.data [2] is 00, and service_id cannot be acquired normally.

This commit fix the problem.

When Response ID is other than 0x7F (Negative Response), it is always Positive Response, so you can get service_id by subtracting 0x40.