### PR TITLE
New Feature: attempt to dump all device identifiers (DIDs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ The target ECU used for the development setup is an STM32F107 based dev-board fr
 * Lear Corporation
 * sigttou
 * FearfulSpoon
+* Alex DeTrano

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -731,8 +731,8 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
     :type timeout: float or None
     :type min_did: int
     :type max_did: int
-    :return: list of response byte values on success, None otherwise
-    :rtype [int] or None
+    :return: list of tuples containing DID and response bytes on success, empty list if no responses
+    :rtype [(int, [int]] or []
     """
     # sanity checks
     if isinstance(timeout, float) and timeout < 0.0:
@@ -754,10 +754,19 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
             if timeout is not None:
                 uds.P3_CLIENT = timeout
 
+            # TODO: set delay
+            # TODO: check if response is valid - current simulator doesn't fully adhere to UDS spec
+
             print('Dumping DIDs in range 0x{:04x}-0x{:04x}\n'.format(min_did, max_did))
             for identifier in range(min_did, max_did + 1):
                 response = uds.read_data_by_identifier(identifier=[identifier])
-                if response:
+
+                # keep the response if we get a positive response
+                # otherwise ignore negative responses
+                # negative responses look like 7f 22 <NRC>
+                if response and Iso14229_1.is_positive_response(response):
+                    # keep the response if we get a positive response
+                    # otherwise ignore negative responses
                     responses.append((identifier, response))
 
             # print result table

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -768,7 +768,7 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
             print('Identified DIDs:')
             print('DID    Value (hex)')
             for response in responses:
-                print(hex(response[0]), list_to_hex_str(response[1]))
+                print('0x{:04x}'.format(response[0]), list_to_hex_str(response[1]))
             return responses
 
 

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -714,11 +714,11 @@ def __dump_dids_wrapper(args):
                      
 
 def dump_dids(arb_id_request, arb_id_response, timeout,
-                  min_did=0x0000, max_did=0xffff):
+                  min_did=DUMP_DID_MIN, max_did=DUMP_DID_MAX):
     """
-    Sends a read data by identifier message to 'arb_id_request'.
-    Returns the first response received from 'arb_id_response' within
-    'timeout' seconds or None otherwise.
+    Sends read data by identifier (DID) messages to 'arb_id_request'.
+    Returns a list of positive responses received from 'arb_id_response' within
+    'timeout' seconds or an empty list if no positive responses were received.
 
     :param arb_id_request: arbitration ID for requests
     :param arb_id_response: arbitration ID for responses
@@ -732,7 +732,7 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
     :type min_did: int
     :type max_did: int
     :return: list of tuples containing DID and response bytes on success, empty list if no responses
-    :rtype [(int, [int]] or []
+    :rtype [(int, [int])] or []
     """
     # sanity checks
     if isinstance(timeout, float) and timeout < 0.0:
@@ -754,9 +754,6 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
             if timeout is not None:
                 uds.P3_CLIENT = timeout
 
-            # TODO: set delay
-            # TODO: check if response is valid - current simulator doesn't fully adhere to UDS spec
-
             print('Dumping DIDs in range 0x{:04x}-0x{:04x}\n'.format(min_did, max_did))
             for identifier in range(min_did, max_did + 1):
                 response = uds.read_data_by_identifier(identifier=[identifier])
@@ -765,8 +762,6 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                 # otherwise ignore negative responses
                 # negative responses look like 7f 22 <NRC>
                 if response and Iso14229_1.is_positive_response(response):
-                    # keep the response if we get a positive response
-                    # otherwise ignore negative responses
                     responses.append((identifier, response))
 
             # print result table

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -709,12 +709,13 @@ def __dump_dids_wrapper(args):
     timeout = args.timeout
     min_did = args.min_did
     max_did = args.max_did
+    print_results=True
     dids = dump_dids(arb_id_request, arb_id_response,
-                     timeout, min_did, max_did)
+                     timeout, min_did, max_did, print_results)
                      
 
 def dump_dids(arb_id_request, arb_id_response, timeout,
-                  min_did=DUMP_DID_MIN, max_did=DUMP_DID_MAX):
+                  min_did=DUMP_DID_MIN, max_did=DUMP_DID_MAX, print_results=True):
     """
     Sends read data by identifier (DID) messages to 'arb_id_request'.
     Returns a list of positive responses received from 'arb_id_response' within
@@ -726,11 +727,13 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                     for default UDS timeout
     :param min_did: minimum device identifier to read
     :param max_did: maximum device identifier to read
+    :param print_results: whether progress should be printed to stdout
     :type arb_id_request: int
     :type arb_id_response: int
     :type timeout: float or None
     :type min_did: int
     :type max_did: int
+    :type print_results: bool
     :return: list of tuples containing DID and response bytes on success, empty list if no responses
     :rtype [(int, [int])] or []
     """
@@ -754,7 +757,8 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
             if timeout is not None:
                 uds.P3_CLIENT = timeout
 
-            print('Dumping DIDs in range 0x{:04x}-0x{:04x}\n'.format(min_did, max_did))
+            if print_results:
+                print('Dumping DIDs in range 0x{:04x}-0x{:04x}\n'.format(min_did, max_did))
             for identifier in range(min_did, max_did + 1):
                 response = uds.read_data_by_identifier(identifier=[identifier])
 
@@ -765,10 +769,11 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                     responses.append((identifier, response))
 
             # print result table
-            print('Identified DIDs:')
-            print('DID    Value (hex)')
-            for response in responses:
-                print('0x{:04x}'.format(response[0]), list_to_hex_str(response[1]))
+            if print_results:
+                print('Identified DIDs:')
+                print('DID    Value (hex)')
+                for response in responses:
+                    print('0x{:04x}'.format(response[0]), list_to_hex_str(response[1]))
             return responses
 
 

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -703,7 +703,7 @@ def send_key(arb_id_request, arb_id_response, level, key, timeout):
             return response
 
 def __dump_dids_wrapper(args):
-    """Wrapper used to initiate device identifier dump"""
+    """Wrapper used to initiate data identifier dump"""
     arb_id_request = args.src
     arb_id_response = args.dst
     timeout = args.timeout

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -103,6 +103,10 @@ VERIFICATION_EXTRA_DELAY = 0.5
 BYTE_MIN = 0x00
 BYTE_MAX = 0xFF
 
+DUMP_DID_MIN = 0x0000
+DUMP_DID_MAX = 0xFFFF
+DUMP_DID_TIMEOUT = 0.2
+
 
 def uds_discovery(min_id, max_id, blacklist_args, auto_blacklist_duration,
                   delay, verify, print_results=True):
@@ -698,6 +702,72 @@ def send_key(arb_id_request, arb_id_response, level, key, timeout):
             response = uds.security_access_send_key(level=level, key=key)
             return response
 
+def __dump_dids_wrapper(args):
+    """Wrapper used to initiate security seed dump"""
+    arb_id_request = args.src
+    arb_id_response = args.dst
+    timeout = args.timeout
+    min_did = args.min_did
+    max_did = args.max_did
+    dids = dump_dids(arb_id_request, arb_id_response,
+                     timeout, min_did, max_did)
+                     
+
+def dump_dids(arb_id_request, arb_id_response, timeout,
+                  min_did=0x0000, max_did=0xffff):
+    """
+    Sends a read data by identifier message to 'arb_id_request'.
+    Returns the first response received from 'arb_id_response' within
+    'timeout' seconds or None otherwise.
+
+    :param arb_id_request: arbitration ID for requests
+    :param arb_id_response: arbitration ID for responses
+    :param timeout: seconds to wait for response before timeout, or None
+                    for default UDS timeout
+    :param min_did: minimum device identifier to read
+    :param max_did: maximum device identifier to read
+    :type arb_id_request: int
+    :type arb_id_response: int
+    :type timeout: float or None
+    :type min_did: int
+    :type max_did: int
+    :return: list of response byte values on success, None otherwise
+    :rtype [int] or None
+    """
+    # sanity checks
+    if isinstance(timeout, float) and timeout < 0.0:
+        raise ValueError("Timeout value ({0}) cannot be negative"
+                         .format(timeout))
+
+    if max_did < min_did:
+        raise ValueError("max_did must not be smaller than min_did -"
+                         " got min:0x{0:x}, max:0x{1:x}".format(
+                          min_did, max_did))
+
+    responses = []
+    with IsoTp(arb_id_request=arb_id_request,
+               arb_id_response=arb_id_response) as tp:
+        # Setup filter for incoming messages
+        tp.set_filter_single_arbitration_id(arb_id_response)
+        with Iso14229_1(tp) as uds:
+            # Set timeout
+            if timeout is not None:
+                uds.P3_CLIENT = timeout
+
+            print('Dumping DIDs in range 0x{:04x}-0x{:04x}\n'.format(min_did, max_did))
+            for identifier in range(min_did, max_did + 1):
+                response = uds.read_data_by_identifier(identifier=[identifier])
+                if response:
+                    responses.append((identifier, response))
+
+            # print result table
+            print('Identified DIDs:')
+            print('DID    Value (hex)')
+            for response in responses:
+                print(hex(response[0]), list_to_hex_str(response[1]))
+            return responses
+
+
 
 def __parse_args(args):
     """Parser for module arguments"""
@@ -843,6 +913,29 @@ def __parse_args(args):
                                      "A '0' is interpreted as infinity. "
                                      "(default: 0)")
     parser_secseed.set_defaults(func=__security_seed_wrapper)
+
+    # Parser for dump_did
+    parser_did = subparsers.add_parser("dump_dids")
+    parser_did.add_argument("src",
+                                type=parse_int_dec_or_hex,
+                                help="arbitration ID to transmit to")
+    parser_did.add_argument("dst",
+                                type=parse_int_dec_or_hex,
+                                help="arbitration ID to listen to")
+    parser_did.add_argument("-t", "--timeout",
+                                  type=float, metavar="T",
+                                  default=DUMP_DID_TIMEOUT,
+                                  help="wait T seconds for response before "
+                                       "timeout")
+    parser_did.add_argument("--min_did",
+                                type=parse_int_dec_or_hex,
+                                default=DUMP_DID_MIN,
+                                help="minimum device identifier (DID) to read (default: 0x0000)")
+    parser_did.add_argument("--max_did",
+                                type=parse_int_dec_or_hex,
+                                default=DUMP_DID_MAX,
+                                help="maximum device identifier (DID) to read (default: 0xFFFF)")
+    parser_did.set_defaults(func=__dump_dids_wrapper)
 
     args = parser.parse_args(args)
     return args

--- a/tool/modules/uds.py
+++ b/tool/modules/uds.py
@@ -703,7 +703,7 @@ def send_key(arb_id_request, arb_id_response, level, key, timeout):
             return response
 
 def __dump_dids_wrapper(args):
-    """Wrapper used to initiate security seed dump"""
+    """Wrapper used to initiate device identifier dump"""
     arb_id_request = args.src
     arb_id_response = args.dst
     timeout = args.timeout

--- a/tool/tests/test_module_uds.py
+++ b/tool/tests/test_module_uds.py
@@ -178,13 +178,14 @@ class UdsModuleTestCase(unittest.TestCase):
     def test_dump_dids(self):
         # mock ECU responds to DIDs 0x0001, 0x0101, 0x0201...0xff01
         # response data is always 6272
-        # so after scanning through 0x0000 - 0xffff there should be 256 responses
+        # scanning 0x0000...0x0101 should yield 2 positive responses out of 258 requests
         # and each response will contain 6272
+        #
         timeout = None
         min_did = 0x0000
-        max_did = 0xffff
+        max_did = 0x0101
         print_results = False
-        expected_response_cnt = 256
+        expected_response_cnt = 2
         expected_response = [0x62, 0x72]
         responses = uds.dump_dids(arb_id_request=self.ARB_ID_REQUEST,
                       arb_id_response=self.ARB_ID_RESPONSE,
@@ -193,7 +194,7 @@ class UdsModuleTestCase(unittest.TestCase):
                       max_did=max_did,
                       print_results=print_results)
 
-        # first check there are 256 responses
+        # first check there are proper number of responses
         self.assertEqual(expected_response_cnt, len(responses))
 
         # next check the responses contain the proper data

--- a/tool/tests/test_module_uds.py
+++ b/tool/tests/test_module_uds.py
@@ -174,3 +174,28 @@ class UdsModuleTestCase(unittest.TestCase):
                              level=level,
                              data_record=data_record,
                              timeout=timeout)
+
+    def test_dump_dids(self):
+        # mock ECU responds to DIDs 0x0001, 0x0101, 0x0201...0xff01
+        # response data is always 6272
+        # so after scanning through 0x0000 - 0xffff there should be 256 responses
+        # and each response will contain 6272
+        timeout = None
+        min_did = 0x0000
+        max_did = 0xffff
+        print_results = False
+        expected_response_cnt = 256
+        expected_response = [0x62, 0x72]
+        responses = uds.dump_dids(arb_id_request=self.ARB_ID_REQUEST,
+                      arb_id_response=self.ARB_ID_RESPONSE,
+                      timeout=timeout,
+                      min_did=min_did,
+                      max_did=max_did,
+                      print_results=print_results)
+
+        # first check there are 256 responses
+        self.assertEqual(expected_response_cnt, len(responses))
+
+        # next check the responses contain the proper data
+        for response in responses:
+            self.assertListEqual(expected_response, response[1])


### PR DESCRIPTION
Hi,
I added the ability to brute force all device identifiers. Not sure if there is any interest for this feature but it's something I thought would be useful and I always end up writing hacky bash scripts to achieve this, so I thought it would be nice to add it to caringcaribou.  The script attempts to issue UDS commands for read data by device identifier (SID 0x22) and only reports positive responses.

You can use it like 
`python3 cc.py uds dump_dids --min_did 0xf187 --max_did 0xf188 0x710 0x7e8`

You need to specify the source arbitration ID, the destination arbitration ID, the range of DIDs using minimum and maximum values.

Help feature looks like:

```
alex@debvm ~/s/c/tool> python3 cc.py uds dump_dids --help

-------------------
CARING CARIBOU v0.3
-------------------

Loaded module 'uds'

usage: cc.py uds dump_dids [-h] [-t T] [--min_did MIN_DID] [--max_did MAX_DID]
                           src dst

positional arguments:
  src                arbitration ID to transmit to
  dst                arbitration ID to listen to

optional arguments:
  -h, --help         show this help message and exit
  -t T, --timeout T  wait T seconds for response before timeout
  --min_did MIN_DID  minimum device identifier (DID) to read (default: 0x0000)
  --max_did MAX_DID  maximum device identifier (DID) to read (default: 0xFFFF)

```


I don't have real hardware to test against so I've been using a virtual CAN bus and simulating an ECU that responds with a positive response to DID 0xf187 and a negative response to 0xf188.  An example run looks like 
```
alex@debvm ~/s/c/tool> python3 cc.py uds dump_dids --min_did 0xf187 --max_did 0xf188 0x710 0x7e8

-------------------
CARING CARIBOU v0.3
-------------------

Loaded module 'uds'

Dumping DIDs in range 0xf187-0xf188

Identified DIDs:
DID    Value (hex)
0xf187 62f1deadbeeffeedface414243
```


I also added a unit test which could probably be improved upon. I am open to suggestions.