### PR TITLE
added support for Pcan on windows, CAN-FD and unlocking

### DIFF
--- a/tool/cc.py
+++ b/tool/cc.py
@@ -70,6 +70,12 @@ def parse_arguments():
                                      epilog=available_modules())
     parser.add_argument("-i", dest="interface", default=None,
                         help="force interface, e.g. 'can1' or 'vcan0'")
+    parser.add_argument("-p", dest="pad", default=None,
+                        help="pad messages with 0s")
+    parser.add_argument("-w", dest="windows", default=None,
+                        help="set bus to PcanBus (works on windows)")
+    parser.add_argument("-fd", dest="canfd", default=None,
+                        help="set bus to CAN-FD mode")
     parser.add_argument("module",
                         help="Name of the module to run")
     parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,
@@ -108,6 +114,12 @@ def main():
     # Save interface to can_actions, for use in modules
     if args.interface:
         lib.can_actions.DEFAULT_INTERFACE = args.interface
+    if args.pad:
+        lib.can_actions.pad = args.pad
+    if args.windows:
+        lib.can_actions.windows=True
+    if args.canfd:
+        lib.can_actions.canfd=args.canfd
     # Dynamically load module
     mod = load_module(args.module)
     if mod is not None:

--- a/tool/lib/common.py
+++ b/tool/lib/common.py
@@ -1,4 +1,7 @@
 
+import string
+
+
 def parse_int_dec_or_hex(value):
     """Parses an integer on base 10 (decimal) or 16 (hex with "0x" prefix)
 
@@ -105,3 +108,7 @@ def msg_to_candump_format(msg):
     data = list_to_hex_str(msg.data, "")
     candump = output.format(msg.timestamp, msg.channel, msg.arbitration_id, data)
     return candump
+
+def is_string(msg):
+    if(str(msg)==msg):
+        return msg

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -1,8 +1,9 @@
-from lib.can_actions import DEFAULT_INTERFACE
-from lib.constants import ARBITRATION_ID_MAX_EXTENDED, ARBITRATION_ID_MAX
+from lib.can_actions import DEFAULT_INTERFACE, windows
+from lib.constants import ARBITRATION_ID_MAX_EXTENDED, ARBITRATION_ID_MAX,pad
 import can
 import datetime
 import time
+from can.interfaces.pcan import PcanBus
 
 
 class IsoTp:
@@ -37,7 +38,9 @@ class IsoTp:
     def __init__(self, arb_id_request, arb_id_response, bus=None):
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
-        if bus is None:
+        if windows:
+            self.bus = PcanBus()
+        elif bus is None:
             self.bus = can.Bus(DEFAULT_INTERFACE)
         else:
             self.bus = bus
@@ -79,6 +82,8 @@ class IsoTp:
         :return: None
         """
         is_extended = force_extended or arbitration_id > ARBITRATION_ID_MAX
+        if pad:
+            data+=[0]*(8-len(data))
         msg = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=is_extended)
         self.bus.send(msg)
 

--- a/tool/lib/unlock_functions.py
+++ b/tool/lib/unlock_functions.py
@@ -1,0 +1,6 @@
+import struct
+
+def example(seed):
+    seed=struct.unpack("L",bytes(seed))[0] #Assumes 4 bytes seed
+    seed+=0x42
+    return list(bytearray(struct.pack("L",seed)))

--- a/tool/tests/mock/mock_ecu.py
+++ b/tool/tests/mock/mock_ecu.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
-from lib.can_actions import DEFAULT_INTERFACE
+from lib.can_actions import DEFAULT_INTERFACE, windows
 import can
+from can.interfaces.pcan import PcanBus
 
 
 class MockEcu:
@@ -10,7 +11,9 @@ class MockEcu:
 
     def __init__(self, bus=None):
         self.message_process = None
-        if bus is None:
+        if windows:
+            self.bus = PcanBus()
+        elif bus is None:
             self.bus = can.Bus(DEFAULT_INTERFACE)
         else:
             self.bus = bus


### PR DESCRIPTION
added support for Pcan on windows, CAN-FD and unlocking using custom key & seed functions.
I used this tool for research and testing mainly on xcp on a project, the need arised for zero padding for my target to respond, using PcanBus as the CANbus directly instead of a linu socketcan interface and the automation of unlocking command groups after reversing the seed and key mehcanism.
Added flags for:
*zero padding
*windows pcan as a bus
*CAN-FD support
Added XCP_unlock in XCP module, intended use is to write a function in "unlock_functions.py" that generates key from seed and to specify as a cli parameter.