### PR TITLE
Added Dump Memory Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Discovers and utilizes various ISO 14229-1 services.
 - services - Scans for diagnostics services supported by an ECU
 - ecu_reset - Reset an ECU
 - testerpresent - Force an elevated session against an ECU to stay active
-- dump_dids - Dumps values of Dynamic Data Identifiers (DIDs)
+- dump_dids - Dumps values of Data Identifiers (DIDs)
+- dump_mem - Dumps memory of ECU
 
 Details here: [uds module](documentation/uds.md)
 
@@ -162,3 +163,4 @@ The target ECU used for the development setup is an STM32F107 based dev-board fr
 * FearfulSpoon
 * Alex DeTrano
 * Thomas Sermpinis
+* Robert Leale (carfucar)

--- a/tool/lib/can_actions.py
+++ b/tool/lib/can_actions.py
@@ -15,7 +15,7 @@ NOTIFIER_STOP_DURATION = 0.5
 
 # Global CAN interface setting, which can be set through the -i flag to cc.py
 # The value None corresponds to the default CAN interface (typically can0)
-DEFAULT_INTERFACE = None
+DEFAULT_INTERFACE = 'vcan0'
 
 
 def auto_blacklist(bus, duration, classifier_function, print_results):
@@ -75,7 +75,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE)
+        self.bus = can.Bus(channel=DEFAULT_INTERFACE, interface='socketcan')
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/tool/lib/iso15765_2.py
+++ b/tool/lib/iso15765_2.py
@@ -38,7 +38,7 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE)
+            self.bus = can.Bus(channel=DEFAULT_INTERFACE, interface='socketcan')
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request


### PR DESCRIPTION
I copied dump_dids and recreated it to support dump memory using the uds.read_memory_by_address method.

I updated the can.Bus() functions to include both "Channel" and "Interface" (optional).

Formatting fixes.