### PR TITLE
raw_send implementation on uds_fuzz module

### DIFF
--- a/caringcaribou/modules/uds_fuzz.py
+++ b/caringcaribou/modules/uds_fuzz.py
@@ -68,9 +68,9 @@ def seed_randomness_fuzzer(args):
                 # Request seed
                 elif session_type[y] == "2" and session_type[y + 1] == "7":
 
+                    service = ServiceID.SECURITY_ACCESS
                     session = str_to_hex(y, session_type)
-                    response = request_seed(arb_id_request, arb_id_response,
-                                            session, None, None)
+                    response = raw_send(arb_id_request, arb_id_response, service, session)
                     if response is None:
                         print("\nInvalid response")
                     elif Iso14229_1.is_positive_response(response):

--- a/caringcaribou/modules/uds_fuzz.py
+++ b/caringcaribou/modules/uds_fuzz.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from caringcaribou.utils.common import list_to_hex_str, parse_int_dec_or_hex, str_to_int_list
 from caringcaribou.utils.iso14229_1 import Iso14229_1, ServiceID
 from caringcaribou.modules.uds import ecu_reset, print_negative_response, extended_session
+from caringcaribou.utils.iso15765_2 import IsoTp
 from sys import stdout
 import argparse
 import time
@@ -41,6 +42,7 @@ def seed_randomness_fuzzer(args):
     inter = args.inter_delay
 
     seed_list = []
+
     try:
 
         # Issue first reset with the supplied delay time

--- a/caringcaribou/modules/uds_fuzz.py
+++ b/caringcaribou/modules/uds_fuzz.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from caringcaribou.utils.common import list_to_hex_str, parse_int_dec_or_hex, str_to_int_list
 from caringcaribou.utils.iso14229_1 import Iso14229_1, ServiceID
-from caringcaribou.modules.uds import ecu_reset, print_negative_response, request_seed, extended_session
+from caringcaribou.modules.uds import ecu_reset, print_negative_response, extended_session
 from sys import stdout
 import argparse
 import time
@@ -148,6 +148,7 @@ def delay_fuzzer(args):
                     service = ServiceID.SECURITY_ACCESS
                     session = str_to_hex(i, session_type)
                     response = raw_send(arb_id_request, arb_id_response, service, session)
+                    
                     if response is None:
                         print("\nInvalid response")
                     elif Iso14229_1.is_positive_response(response):


### PR DESCRIPTION
Implementation of the raw_send function developed for the uds module, in order to bypass the restrictions of OEM specific security access levels. Applicable to both submodules.