### PR TITLE
Fix Issue 84: Enhancements in command line interface to match `python-can` naming convention

### DIFF
--- a/caringcaribou/caringcaribou.py
+++ b/caringcaribou/caringcaribou.py
@@ -75,7 +75,11 @@ def parse_arguments():
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      epilog=available_modules())
     parser.add_argument("-i", dest="interface", default=None,
-                        help="force interface, e.g. 'can1' or 'vcan0'")
+                        help="force interface, e.g. 'socketcan', 'pcan', or 'vector'")
+    parser.add_argument("-c", dest="channel", default=None,
+                        help="force channel, e.g. 'can0', 'can1', or 'vcan0'")
+    parser.add_argument("-b", dest="bitrate", default=None,
+                        help="force bitrate, e.g. '250000' or '500000'")
     parser.add_argument("module",
                         help="Name of the module to run")
     parser.add_argument("module_args", metavar="...", nargs=argparse.REMAINDER,
@@ -110,6 +114,8 @@ def main():
     # Save interface to can_actions, for use in modules
     if args.interface:
         can_actions.DEFAULT_INTERFACE = args.interface
+        can_actions.DEFAULT_CHANNEL = args.channel
+        can_actions.DEFAULT_BITRATE = args.bitrate
     try:
         # Load module
         cc_mod = load_module(args.module).load()

--- a/caringcaribou/utils/can_actions.py
+++ b/caringcaribou/utils/can_actions.py
@@ -13,9 +13,11 @@ MESSAGE_DELAY = 0.1
 DELAY_STEP = 0.02
 NOTIFIER_STOP_DURATION = 0.5
 
-# Global CAN interface setting, which can be set through the -i flag to cc.py
-# The value None corresponds to the default CAN interface (typically can0)
+# Global CAN interface settings, which can be set through the '-i', '-c', '-b' flags to cc.py
+# The value None corresponds to the default CAN interface, channel, and bitrate
 DEFAULT_INTERFACE = None
+DEFAULT_CHANNEL = None
+DEFAULT_BITRATE = None
 
 
 def auto_blacklist(bus, duration, classifier_function, print_results):
@@ -75,7 +77,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE)
+        self.bus = can.Bus(interface = DEFAULT_INTERFACE, channel = DEFAULT_CHANNEL, bitrate = DEFAULT_BITRATE)
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/caringcaribou/utils/iso15765_2.py
+++ b/caringcaribou/utils/iso15765_2.py
@@ -1,4 +1,4 @@
-from caringcaribou.utils.can_actions import DEFAULT_INTERFACE
+from caringcaribou.utils.can_actions import DEFAULT_INTERFACE, DEFAULT_CHANNEL, DEFAULT_BITRATE
 from caringcaribou.utils.constants import ARBITRATION_ID_MAX_EXTENDED, ARBITRATION_ID_MAX
 import can
 import datetime
@@ -38,7 +38,7 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE)
+            self.bus = can.Bus(DEFAULT_INTERFACE, DEFAULT_CHANNEL, DEFAULT_BITRATE)
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request

--- a/documentation/howtouse.md
+++ b/documentation/howtouse.md
@@ -7,7 +7,7 @@ This will list all available modules at the bottom of the output:
 
 ```
 $ cc.py -h
-usage: cc.py [-h] [-i INTERFACE] module ...
+usage: cc.py [-h] [-i INTERFACE] [-c CHANNEL] [-b BITRATE] module ...
 
 -------------------
 CARING CARIBOU v0.x
@@ -27,7 +27,9 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
-  -i INTERFACE  force interface, e.g. 'can1' or 'vcan0'
+  -i INTERFACE  force interface, e.g. 'socketcan', 'pcan', or 'vector'
+  -c CHANNEL    force channel, e.g. 'can0', 'can1', or 'vcan0'
+  -b BITRATE    force bitrate, e.g. '250000' or '500000'
 
 available modules:
   dcm, dump, fuzzer, listener, send, test, xcp

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -23,7 +23,7 @@ Documentation for python-can: https://python-can.readthedocs.io/en/master/config
 
 ### Inactive CAN interface
 #### Symptoms
-Running a module with an interface specified through `-i` gives the following error:
+Running a module with a channel specified through `-c` gives the following error:
 `IOError: [Errno 19] No such device. This might be caused by an invalid or inactive CAN interface.`
 
 #### Solution
@@ -56,3 +56,11 @@ ImportError: No module named can
 
 #### Solution
 Install python-can. This can be done by running `pip install python-can`
+
+### Deprecated command line arguments
+#### Symptoms
+Running a module specifying a channel as an interface using `-i` (e.g. `cc.py -i can0`) gives the following error:
+`can.exceptions.CanInterfaceNotImplementedError: Unknown interface type "can0"`
+
+### Solutions
+Use the updated command line flags to specify the `interface` using `-i`, the `channel` using `-c` and the bitrate `-b` (e.g. `cc.py -i socketcan -c can0 -b 500000`).


### PR DESCRIPTION
- Fixes #84 
- Added 'channel', and 'bitrate' as command line arguments
- Modified 'interface' argument to use python-can naming convention
- Updated documentation to match changes in command line arguments
- Updated troubleshooting guide to support the changes in the CLI