### PR TITLE
Fixed missing context arg when creating CAN bus

### DIFF
--- a/caringcaribou/utils/can_actions.py
+++ b/caringcaribou/utils/can_actions.py
@@ -75,7 +75,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE)
+        self.bus = can.Bus(context=DEFAULT_INTERFACE)
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None


### PR DESCRIPTION
When using the configuration of python-can, it was guided to pass interface settings through context, so I made the modification.

https://python-can.readthedocs.io/en/stable/configuration.html

I have verified that it works properly with python-can-remote.
Please review and provide feedback.
