### PR TITLE
Fixed missing context arg when creating CAN bus

### DIFF
--- a/can.ini
+++ b/can.ini
@@ -1,0 +1,9 @@
+[default]
+interface=virtual
+channel=vcan0
+
+[remote]
+interface=remote
+channel=ws://localhost:54701
+bitrate=50000
+receive_own_messages=True

--- a/caringcaribou/tests/mock/mock_ecu.py
+++ b/caringcaribou/tests/mock/mock_ecu.py
@@ -11,7 +11,7 @@ class MockEcu:
     def __init__(self, bus=None):
         self.message_process = None
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE)
+            self.bus = can.Bus(context=DEFAULT_INTERFACE)
         else:
             self.bus = bus
 

--- a/caringcaribou/tests/test_iso_14229_1.py
+++ b/caringcaribou/tests/test_iso_14229_1.py
@@ -17,7 +17,7 @@ class DiagnosticsOverIsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIso14229(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE)
+        can_bus = can.Bus(context=DEFAULT_INTERFACE)
         # Setup diagnostics on top of ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
         self.diagnostics = iso14229_1.Iso14229_1(self.tp)

--- a/caringcaribou/tests/test_iso_15765_2.py
+++ b/caringcaribou/tests/test_iso_15765_2.py
@@ -16,7 +16,7 @@ class IsoTpTestCase(unittest.TestCase):
         self.ecu = MockEcuIsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE)
         self.ecu.start_server()
         # Initialize virtual CAN bus
-        can_bus = can.Bus(DEFAULT_INTERFACE)
+        can_bus = can.Bus(context=DEFAULT_INTERFACE)
         # Setup ISO-TP layer
         self.tp = iso15765_2.IsoTp(self.ARB_ID_REQUEST, self.ARB_ID_RESPONSE, bus=can_bus)
 

--- a/caringcaribou/utils/can_actions.py
+++ b/caringcaribou/utils/can_actions.py
@@ -75,7 +75,7 @@ class CanActions:
         :param arb_id: int default arbitration ID for object or None
         :param notifier_enabled: bool indicating whether a notifier for incoming message callbacks should be enabled
         """
-        self.bus = can.Bus(DEFAULT_INTERFACE)
+        self.bus = can.Bus(context=DEFAULT_INTERFACE)
         self.arb_id = arb_id
         self.bruteforce_running = False
         self.notifier = None

--- a/caringcaribou/utils/iso15765_2.py
+++ b/caringcaribou/utils/iso15765_2.py
@@ -38,7 +38,7 @@ class IsoTp:
         # Setting default bus to None rather than the actual bus prevents a CanError when
         # called with a virtual CAN bus, while the OS is lacking a working CAN interface
         if bus is None:
-            self.bus = can.Bus(DEFAULT_INTERFACE)
+            self.bus = can.Bus(context=DEFAULT_INTERFACE)
         else:
             self.bus = bus
         self.arb_id_request = arb_id_request


### PR DESCRIPTION
When using the configuration of python-can, it was guided to pass interface settings through context, so I made the modification.

https://python-can.readthedocs.io/en/stable/configuration.html

I have verified that it works properly with python-can-remote.
Please review and provide feedback.
