### PR TITLE
fixed dump_dids bug so only the DID value is displayed

### DIFF
--- a/caringcaribou/modules/uds.py
+++ b/caringcaribou/modules/uds.py
@@ -1077,7 +1077,11 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                 # Only keep positive responses
                 if response and Iso14229_1.is_positive_response(response):
                     responses.append((identifier, response))
-                    if print_results:
+                    # only display the data record portion of the payload
+                    # response[0] = response SID (0x62)
+                    # response[1:3] = Data Identifier (DID)
+                    # response[3:] = data
+                    if print_results and len(response) > 3:
                         print('0x{:04x}'.format(identifier), list_to_hex_str(response[3:]))
             if print_results:
                 print("\nDone!")

--- a/caringcaribou/modules/uds.py
+++ b/caringcaribou/modules/uds.py
@@ -1078,7 +1078,7 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                 if response and Iso14229_1.is_positive_response(response):
                     responses.append((identifier, response))
                     if print_results:
-                        print('0x{:04x}'.format(identifier), list_to_hex_str(response))
+                        print('0x{:04x}'.format(identifier), list_to_hex_str(response[3:]))
             if print_results:
                 print("\nDone!")
             return responses


### PR DESCRIPTION
dump_did output mistakenly contained the response code and the requested DID. This commit removes that information and only displays the DID payload to the user.