### PR TITLE
only show relevant DID reads

### DIFF
--- a/caringcaribou/modules/uds.py
+++ b/caringcaribou/modules/uds.py
@@ -1076,6 +1076,10 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
 
                 # Only keep positive responses
                 if response and Iso14229_1.is_positive_response(response):
+                    # sometimes there are other modules reading DIDs at the same time
+                    # try to filter out extranous DID reads by comparing the value
+                    if identifier != int(list_to_hex_str(response[1:3]), 16):
+                        continue
                     responses.append((identifier, response))
                     if print_results:
                         print('0x{:04x}'.format(identifier), list_to_hex_str(response))


### PR DESCRIPTION
on a real CAN bus, sometimes other ECUs are also performing DID reads. This commit checks the DID value in the response against the requested DID value. If they do not match, the response is extraneous and is not shown to the user.