### PR TITLE
Progress indicator dump_did

### DIFF
--- a/caringcaribou/modules/uds.py
+++ b/caringcaribou/modules/uds.py
@@ -1078,7 +1078,7 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                 if response and Iso14229_1.is_positive_response(response):
                     responses.append((identifier, response))
                     if print_results:
-                        print('0x{:04x}'.format(identifier), list_to_hex_str(response))
+                        print('0x{:04x}'.format(identifier), list_to_hex_str(response[3:]))
             if print_results:
                 print("\nDone!")
             return responses

--- a/caringcaribou/modules/uds.py
+++ b/caringcaribou/modules/uds.py
@@ -5,7 +5,7 @@ from caringcaribou.utils.constants import ARBITRATION_ID_MAX, ARBITRATION_ID_MAX
 from caringcaribou.utils.constants import ARBITRATION_ID_MIN
 from caringcaribou.utils.iso15765_2 import IsoTp
 from caringcaribou.utils.iso14229_1 import Constants, Iso14229_1, NegativeResponseCodes, Services, ServiceID
-from sys import stdout, version_info
+from sys import stdout, version_info, stderr
 import argparse
 import datetime
 import time
@@ -1072,6 +1072,7 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                 print('Identified DIDs:')
                 print('DID    Value (hex)')
             for identifier in range(min_did, max_did + 1):
+                print(f'0x{identifier:04x}', end='\r', file=stderr)
                 response = uds.read_data_by_identifier(identifier=[identifier])
 
                 # Only keep positive responses
@@ -1084,7 +1085,8 @@ def dump_dids(arb_id_request, arb_id_response, timeout,
                     if print_results:
                         print('0x{:04x}'.format(identifier), list_to_hex_str(response[3:]))
             if print_results:
-                print("\nDone!")
+                print("\033[K", file=stderr) # clear line
+                print("Done!")
             return responses
 
 


### PR DESCRIPTION
shows the current DID being read in the output.  This way the tester knows how far along the DID reading progress is going. The final output remains unchanged - only while the tool is running do we see the DID value changing.