### PR TITLE
filter extraneous DIDs + valid testing

### DIFF
--- a/caringcaribou/tests/mock/mock_ecu_uds.py
+++ b/caringcaribou/tests/mock/mock_ecu_uds.py
@@ -158,6 +158,12 @@ class MockEcuIso14229(MockEcuIsoTp, MockEcu):
             # Request for negative response - use Conditions Not Correct
             nrc = NegativeResponseCodes.CONDITIONS_NOT_CORRECT
             response_data = self.create_negative_response(service_id, nrc)
+        # special DID that responds with DID + 1
+        elif data_id == [0xff, 0xfe]:
+            print('found special DID')
+            payload = [0xff, 0xff, self.IDENTIFIER_REQUEST_POSITIVE_RESPONSE]
+            print(f'{payload=}')
+            response_data = self.create_positive_response(service_id, payload)
         else:
             # Unmatched request - use a general reject response
             nrc = NegativeResponseCodes.GENERAL_REJECT

--- a/caringcaribou/tests/mock/mock_ecu_uds.py
+++ b/caringcaribou/tests/mock/mock_ecu_uds.py
@@ -162,7 +162,7 @@ class MockEcuIso14229(MockEcuIsoTp, MockEcu):
         elif data_id == [0xff, 0xfe]:
             print('found special DID')
             payload = [0xff, 0xff, self.IDENTIFIER_REQUEST_POSITIVE_RESPONSE]
-            print(f'{payload=}')
+            print(f'payload={payload}')
             response_data = self.create_positive_response(service_id, payload)
         else:
             # Unmatched request - use a general reject response

--- a/caringcaribou/tests/mock/mock_ecu_uds.py
+++ b/caringcaribou/tests/mock/mock_ecu_uds.py
@@ -145,12 +145,14 @@ class MockEcuIso14229(MockEcuIsoTp, MockEcu):
         :return: Response to be sent
         """
         service_id = data[0]
+        data_id = data[1:3]
         request = data[2]
 
         if request == self.IDENTIFIER_REQUEST_POSITIVE:
             # Request for positive response
             # TODO Actually read a parameter from memory
-            payload = [self.IDENTIFIER_REQUEST_POSITIVE_RESPONSE]
+            payload = data_id
+            payload.append(self.IDENTIFIER_REQUEST_POSITIVE_RESPONSE)
             response_data = self.create_positive_response(service_id, payload)
         elif request == self.IDENTIFIER_REQUEST_NEGATIVE:
             # Request for negative response - use Conditions Not Correct

--- a/caringcaribou/tests/test_iso_14229_1.py
+++ b/caringcaribou/tests/test_iso_14229_1.py
@@ -75,8 +75,15 @@ class DiagnosticsOverIsoTpTestCase(unittest.TestCase):
     def test_read_data_by_identifier_success(self):
         service_id = iso14229_1.ServiceID.READ_DATA_BY_IDENTIFIER
         identifier = [MockEcuIso14229.IDENTIFIER_REQUEST_POSITIVE]
-        expected_response = [MockEcuIso14229.IDENTIFIER_REQUEST_POSITIVE_RESPONSE]
+        expected_response = [0x00,
+                             MockEcuIso14229.IDENTIFIER_REQUEST_POSITIVE,
+                             MockEcuIso14229.IDENTIFIER_REQUEST_POSITIVE_RESPONSE]
         result = self.diagnostics.read_data_by_identifier(identifier=identifier)
+
+        # result looks like [0x62, DID_ADDR_UPPER, DID_ADDR_LOWER, RESULT]
+        #rsp_pos = result[0]
+        #rx_identifier = result[1:3]
+        print(result)
         self.verify_positive_response(service_id, result, expected_response)
 
     def test_read_data_by_identifier_failure(self):

--- a/caringcaribou/tests/test_module_uds.py
+++ b/caringcaribou/tests/test_module_uds.py
@@ -205,3 +205,20 @@ class UdsModuleTestCase(unittest.TestCase):
                 self.assertListEqual(expected_responses[0], full_response)
             elif full_response[0:2] == [1,1]:
                 self.assertListEqual(expected_responses[1], full_response)
+
+        # check if we read a DID and the response comes back with a different DID
+        # testing harness will respond with DID + 1 when reading DID 0xfffe
+        expected_response_cnt = 0
+        expected_responses = [[0x62, 0x00, 0x01, 0x72]]
+        responses = uds.dump_dids(arb_id_request=self.ARB_ID_REQUEST,
+                                  arb_id_response=self.ARB_ID_RESPONSE,
+                                  timeout=timeout,
+                                  min_did=0xfffe,
+                                  max_did=0xfffe,
+                                  print_results=print_results)
+
+        # check there are proper number of responses - should be 0
+        # since we don't keep responses that don't align with the requested DID
+        self.assertEqual(expected_response_cnt, len(responses))
+
+

--- a/caringcaribou/tests/test_module_uds.py
+++ b/caringcaribou/tests/test_module_uds.py
@@ -176,17 +176,16 @@ class UdsModuleTestCase(unittest.TestCase):
                              timeout=timeout)
 
     def test_dump_dids(self):
-        # mock ECU responds to DIDs 0x0001, 0x0101, 0x0201...0xff01
-        # response data is always 6272
-        # scanning 0x0000...0x0101 should yield 2 positive responses out of 258 requests
-        # and each response will contain 6272
+        # mock ECU responds to DIDs 0x0001, 0x0101, 0x0201...
+        # response data is always 62, 00, 01, 72
+        # scanning 0x0000...0x0101 should yield 1 positive responses out of 258 requests
         #
         timeout = None
         min_did = 0x0000
-        max_did = 0x0101
+        max_did = 0x0100
         print_results = False
-        expected_response_cnt = 2
-        expected_response = [0x62, 0x72]
+        expected_response_cnt = 1
+        expected_responses = [[0x62, 0x00, 0x01, 0x72]]
         responses = uds.dump_dids(arb_id_request=self.ARB_ID_REQUEST,
                                   arb_id_response=self.ARB_ID_RESPONSE,
                                   timeout=timeout,
@@ -199,4 +198,10 @@ class UdsModuleTestCase(unittest.TestCase):
 
         # next check the responses contain the proper data
         for response in responses:
-            self.assertListEqual(expected_response, response[1])
+            # response is a tuple (data_identifier, response)
+            identifier = response[0]
+            full_response = response[1:][0] # data comes out 
+            if full_response[0:2] == [0, 1]:
+                self.assertListEqual(expected_responses[0], full_response)
+            elif full_response[0:2] == [1,1]:
+                self.assertListEqual(expected_responses[1], full_response)


### PR DESCRIPTION
latest code that ensures we only respond to DIDs that we requested. Testing infrastructure has been updated to take this into account. The big change here was updating the mock ECU to respond properly to a DID request. It was not responding with the requested DID and causing tests to fail.

I also rolled in some code cleanup around checking the length of the DID to avoid multiple indentations from nested if statements.