### PR TITLE
Use importlib.resources to fix module loading

### DIFF
--- a/caringcaribou/caringcaribou.py
+++ b/caringcaribou/caringcaribou.py
@@ -58,16 +58,12 @@ def available_modules_dict():
 
     # List all the available resources in the package
     module_names = importlib.resources.contents(package_name)
-    module_names = [name for name in module_names if name.endswith('.py') and name != '__init__.py']
+    module_names = [name for name in module_names if name.endswith(".py") and name != "__init__.py"]
 
     for module_name in module_names:
         nice_name = module_name[:-3]  # Strip the .py extension
-        module_full_name = f'{package_name}.{nice_name}'
-        try:
-            module = importlib.import_module(module_full_name)
-            modules[nice_name] = module
-        except ImportError as e:
-            print(f"Could not import module {module_full_name}: {e}")
+        module_full_name = f"{package_name}.{nice_name}"
+        modules[nice_name] = module_full_name
     return modules
 
 
@@ -116,7 +112,8 @@ def load_module(module_name):
     """
     try:
         print("Loading module '{0}'\n".format(module_name))
-        cc_mod = available_modules_dict()[module_name]
+        full_module_name = available_modules_dict()[module_name]
+        cc_mod = importlib.import_module(full_module_name)
         return cc_mod
     except KeyError as e:
         print("Load module failed: module {0} is not available".format(e))
@@ -134,7 +131,7 @@ def main():
         can_actions.DEFAULT_INTERFACE = args.interface
     try:
         # Load module
-        cc_mod = load_module(args.module).load()
+        cc_mod = load_module(args.module)
         cc_mod.module_main(args.module_args)
     except AttributeError:
         pass

--- a/caringcaribou/caringcaribou.py
+++ b/caringcaribou/caringcaribou.py
@@ -7,7 +7,8 @@ import errno
 from .utils import can_actions
 import sys
 import traceback
-import pkg_resources
+import importlib
+import importlib.resources
 
 
 VERSION = "0.6"
@@ -53,9 +54,20 @@ def show_missing_canrc_instruction():
 
 def available_modules_dict():
     modules = dict()
-    for entry_point in pkg_resources.iter_entry_points("caringcaribou.modules"):
-        nice_name = str(entry_point).split("=")[0].strip()
-        modules[nice_name] = entry_point
+    package_name = 'caringcaribou.modules'
+
+    # List all the available resources in the package
+    module_names = importlib.resources.contents(package_name)
+    module_names = [name for name in module_names if name.endswith('.py') and name != '__init__.py']
+
+    for module_name in module_names:
+        nice_name = module_name[:-3]  # Strip the .py extension
+        module_full_name = f'{package_name}.{nice_name}'
+        try:
+            module = importlib.import_module(module_full_name)
+            modules[nice_name] = module
+        except ImportError as e:
+            print(f"Could not import module {module_full_name}: {e}")
     return modules
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,44 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "caringcaribou"
-authors = [{name = "Kasper Karlsson"}]
+version = "0.6"
+description = "A friendly automotive security exploration tool"
 readme = "README.md"
-license = {file = "LICENSE"}
-classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
-dynamic = ["version", "description"]
+authors = [{ name = "Kasper Karlsson" }]
+license = { file = "LICENSE" }
 keywords = ["automotive", "security", "CAN", "automotive protocols", "fuzzing"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
+]
+dependencies = ["python-can"]
+
+[project.urls]
+Homepage = "https://github.com/CaringCaribou/caringcaribou"
+Download = "https://github.com/CaringCaribou/caringcaribou/archive/master.tar.gz"
+
+[project.optional-dependencies]
+test = ["pytest", "tox"]
+
+[project.scripts]
+caringcaribou = "caringcaribou.caringcaribou:main"
+
+[project.entry-points."caringcaribou.modules"]
+dcm = "caringcaribou.modules.dcm"
+doip = "caringcaribou.modules.doip"
+dump = "caringcaribou.modules.dump"
+fuzzer = "caringcaribou.modules.fuzzer"
+listener = "caringcaribou.modules.listener"
+send = "caringcaribou.modules.send"
+test = "caringcaribou.modules.test"
+uds_fuzz = "caringcaribou.modules.uds_fuzz"
+uds = "caringcaribou.modules.uds"
+xcp = "caringcaribou.modules.xcp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,4 @@ readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 dynamic = ["version", "description"]
+keywords = ["automotive", "security", "CAN", "automotive protocols", "fuzzing"]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     # author_email="TBD",
     description="A friendly automotive security exploration tool",
     long_description=__doc__,
-    keywords=["automotive", "security", "CAN", "automotive protocols", "fuzzing"],
     url="https://github.com/CaringCaribou/caringcaribou/",
     download_url="https://github.com/CaringCaribou/caringcaribou/tarball/{}".format(dl_version),
     license="GPLv3",


### PR DESCRIPTION
When running caringcaribou from a local directory with `python3 -m caringcaribou.caringcaribou -h`, no modules are found.

Furthermore, pkg_resources is a deprecated API:

  DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

Refactor the module loading code to fix loading modules when running from a local directory as well as fix the code which uses a deprecated API.