### PR TITLE
Contributor name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The target ECU used for the development setup is an STM32F107 based dev-board fr
 * Filip Hesslund
 * Craig Smith (OpenGarages.org)
 * internot
-* Mathijs Hubrechtsen
+* Roos Hubrechtsen
 * Lear Corporation
 * sigttou
 * FearfulSpoon


### PR DESCRIPTION
A few years ago I contributed the "fuzzer" module to caring caribou and since then I have been listed as a contributor. However, since that time my name has changed -- this change would reflect that name change in the README file.