### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The `caringcaribou/tests` folder contains automated test suites and `/documentat
 A clean installation of Caring Caribou includes the following modules:
 
 ### dump - Dump CAN traffic
-
 Dumps incoming traffic to stdout (terminal output) or file
 
 Details here: [dump module](documentation/dump.md)

--- a/README.md
+++ b/README.md
@@ -40,36 +40,8 @@ The `caringcaribou/tests` folder contains automated test suites and `/documentat
 ## List of Modules
 A clean installation of Caring Caribou includes the following modules:
 
-### uds - Universal Diagnostic Services
-Discovers and utilizes various ISO 14229-1 services.
-- discovery - Scans for ECUs supporting diagnostics services
-- services - Scans for diagnostics services supported by an ECU
-- subservices - Subservice enumeration of supported diagnostics services by an ECU
-- ecu_reset - Reset an ECU
-- testerpresent - Force an elevated session against an ECU to stay active
-- dump_dids - Dumps values of Dynamic Data Identifiers (DIDs)
-- read_mem - Read memory from an ECU
-- auto - Fully automated diagnostics scan, by using the already existing UDS submodules
-
-Details here: [uds module](documentation/uds.md)
-
-### xcp - Universal Measurement and Calibration Protocol (XCP)
-- discovery - Scans for ECUs supporting XCP
-- info - XCP Get Basic Information. Retrieves information about XCP abilities of an ECU
-- dump - XCP Upload. Used to dump ECU memory (such as SRAM, flash and bootloader) to file 
-
-Details here: [xcp module](documentation/xcp.md)
-
-### fuzzer - CAN fuzzer
-- random - sends random CAN messages
-- brute - brute forces all possible messages matching a given bit mask
-- mutate - mutate selected nibbles of a given message
-- replay - replay a log file from a previous fuzzing session
-- identify - replay a log file and identify message causing a specific event
-
-Details here: [fuzzer module](documentation/fuzzer.md)
-
 ### dump - Dump CAN traffic
+
 Dumps incoming traffic to stdout (terminal output) or file
 
 Details here: [dump module](documentation/dump.md)
@@ -84,13 +56,28 @@ Lists all distinct arbitration IDs being used on the CAN bus
 
 Details here: [listener module](documentation/listener.md)
 
-### test - Run test suite
-Runs automated Caring Caribou test suites
+### fuzzer - CAN fuzzer
+- random - sends random CAN messages
+- brute - brute forces all possible messages matching a given bit mask
+- mutate - mutate selected nibbles of a given message
+- replay - replay a log file from a previous fuzzing session
+- identify - replay a log file and identify message causing a specific event
 
-### dcm - [deprecated] Diagnostics Control Module
-**Note**: This module has been replaced by the [UDS](documentation/uds.md) module. It is still supported by CC due to legacy reasons.
+Details here: [fuzzer module](documentation/fuzzer.md)
 
-Details here: [dcm module](documentation/dcm.md)
+### uds - Universal Diagnostic Services
+Discovers and utilizes various ISO 14229-1 services.
+- discovery - Scans for ECUs supporting diagnostics services
+- services - Scans for diagnostics services supported by an ECU
+- subservices - Subservice enumeration of supported diagnostics services by an ECU
+- ecu_reset - Reset an ECU
+- testerpresent - Force an elevated session against an ECU to stay active
+- security_seed - An automated way to collect seeds for a specific security access level in a specific diagnostic session
+- dump_dids - Dumps values of Dynamic Data Identifiers (DIDs)
+- read_mem - Read memory from an ECU
+- auto - Fully automated diagnostics scan, by using the already existing UDS submodules
+
+Details here: [uds module](documentation/uds.md)
 
 ### uds_fuzz - Universal Diagnostic Services Fuzzer
 Fuzzing module for UDS security seed randomness evaluation and testing.
@@ -110,6 +97,21 @@ Discovers and utilizes various ISO 13400-2 services.
 - seed_randomness_fuzzer - ECUReset method fuzzing for seed randomness evaluation
 
 Details here: [doip module](documentation/doip.md)
+
+### xcp - Universal Measurement and Calibration Protocol (XCP)
+- discovery - Scans for ECUs supporting XCP
+- info - XCP Get Basic Information. Retrieves information about XCP abilities of an ECU
+- dump - XCP Upload. Used to dump ECU memory (such as SRAM, flash and bootloader) to file 
+
+Details here: [xcp module](documentation/xcp.md)
+
+### dcm - [deprecated] Diagnostics Control Module
+**Note**: This module has been replaced by the [UDS](documentation/uds.md) module. It is still supported by CC due to legacy reasons.
+
+Details here: [dcm module](documentation/dcm.md)
+
+### test - Run test suite
+Runs automated Caring Caribou test suites
 
 ## List of libraries/utilities
 The `caringcaribou/utils` folder contains the following:

--- a/caringcaribou/modules/dcm.py
+++ b/caringcaribou/modules/dcm.py
@@ -426,7 +426,8 @@ def parse_args(args):
     """
     parser = argparse.ArgumentParser(prog="caringcaribou dcm",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     description="""Diagnostics module for CaringCaribou""",
+                                     description="""Diagnostics module for CaringCaribou
+DeprecationWarning: The DCM module has been replaced by the UDS module""",
                                      epilog="""Example usage:
   caringcaribou dcm discovery
   caringcaribou dcm discovery -blacklist 0x123 0x456

--- a/documentation/dcm.md
+++ b/documentation/dcm.md
@@ -1,4 +1,6 @@
 # DCM
+> _**Note**: This module has been replaced by the [UDS](./uds.md) module. It is still supported by CC due to legacy reasons._
+
 ```
 $ caringcaribou dcm -h
 

--- a/documentation/dcm.md
+++ b/documentation/dcm.md
@@ -1,5 +1,5 @@
 # DCM
-> _**Note**: This module has been replaced by the [UDS](./uds.md) module. It is still supported by CC due to legacy reasons._
+> _**Note**: This module has been replaced by the [UDS](uds.md) module. It is still supported by CaringCaribou due to legacy reasons._
 
 ```
 $ caringcaribou dcm -h

--- a/documentation/howtouse.md
+++ b/documentation/howtouse.md
@@ -155,7 +155,6 @@ On our system we found two active arbitration IDs: 0x001 and 0x002 - probably se
 
 Now let's investigate if diagnostics are present on some ECUs. Thanks to 'listener' results, we know that there is no need to do discovery on 0x001 and 0x002, so lets start from ID 0x003.
 
-
 Start uds discovery from arbitration ID 0x003:
 ```
 $ caringcaribou uds discovery -min 0x003

--- a/documentation/listener.md
+++ b/documentation/listener.md
@@ -20,7 +20,7 @@ optional arguments:
  -r, --reverse  Reversed sorting of results
 ```
 
-# Example use:
+Example use:
 ```
 $ caringcaribou listener
 

--- a/documentation/listener.md
+++ b/documentation/listener.md
@@ -1,5 +1,8 @@
 # Listener
-````
+It's a mode dedicated to listening on the CAN bus and logging all detected arbitration IDs.
+
+Opening the help menu:
+```
 $ caringcaribou listener -h
 
 -------------------
@@ -15,4 +18,26 @@ Passive listener module for CaringCaribou
 optional arguments:
  -h, --help     show this help message and exit
  -r, --reverse  Reversed sorting of results
- ```
+```
+
+# Example use:
+```
+$ caringcaribou listener
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'listener'
+
+Running listener (press Ctrl+C to exit)
+Last ID: 0x002 (2 unique arbitration IDs found)
+```
+(stop the listener with ctrl-C)
+```
+Detected arbitration IDs:
+Arb id 0x001 114 hits
+Arb id 0x002 13 hits
+
+```
+In the above example, two arbitration IDs were detected. The message with ID 0x001 was seen on the CAN bus 114 times, while the one with ID 0x002 appeared 13 times.

--- a/documentation/uds.md
+++ b/documentation/uds.md
@@ -10,6 +10,7 @@ Supported modes:
 * subservices - Subservice enumeration of supported diagnostics services by an ECU
 * ecu_reset - Reset an ECU
 * testerpresent - Force an elevated diagnostics session against an ECU to stay active
+* security_seed - An automated way to collect seeds for a specific security access level in a specific diagnostic session
 * dump_dids - Dumps values of Dynamic Data Identifiers (DIDs)
 * read_mem - Read memory from an ECU
 * auto - Fully automated diagnostics scan, by using the already existing UDS submodules
@@ -80,6 +81,30 @@ optional arguments:
   -d D, --delay D       D seconds delay between messages (default: 0.01)
 ```
 
+Example use:
+```
+$ caringcaribou uds discovery
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'uds'
+
+Sending Diagnostic Session Control to 0x07e0
+  Verifying potential response from 0x07e0
+    Resending 0x7e0...  Success
+Found diagnostics server listening at 0x07e0, response at 0x07e8
+
+Identified diagnostics:
+
++------------+------------+
+| CLIENT ID  | SERVER ID  |
++------------+------------+
+| 0x000007e0 | 0x000007e8 |
++------------+------------+
+```
+
 ## Services
 Scans an ECU (or rather, a given pair of request/response arbitration IDs) for supported diagnostics services.
 
@@ -102,6 +127,41 @@ optional arguments:
   -h, --help         show this help message and exit
   -t T, --timeout T  wait T seconds for response before timeout (default: 0.2)
 ```
+
+Example use:
+```
+$ caringcaribou uds services 0x7E0 0x7E8
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'uds'
+
+Probing service 0xff (255/255): found 19
+Done!
+
+Supported service 0x01: Unknown service
+Supported service 0x02: Unknown service
+Supported service 0x03: Unknown service
+Supported service 0x04: Unknown service
+Supported service 0x04: Unknown service
+Supported service 0x38: Unknown service
+Supported service 0x09: Unknown service
+Supported service 0x10: DIAGNOSTIC_SESSION_CONTROL
+Supported service 0x11: ECU_RESET
+Supported service 0x19: READ_DTC_INFORMATION
+Supported service 0x22: READ_DATA_BY_IDENTIFIER
+Supported service 0x23: READ_MEMORY_BY_ADDRESS
+Supported service 0x27: SECURITY_ACCESS
+Supported service 0x28: COMMUNICATION_CONTROL
+Supported service 0x2e: WRITE_DATA_BY_IDENTIFIER
+Supported service 0x2f: INPUT_OUTPUT_CONTROL_BY_IDENTIFIER
+Supported service 0x31: ROUTINE_CONTROL
+Supported service 0x3e: TESTER_PRESENT
+Supported service 0x85: CONTROL_DTC_SETTING
+```
+
 
 ## Sub-services
 Scans a diagnostics service ID for supported sub-service IDs.
@@ -209,6 +269,116 @@ optional arguments:
   --min_did MIN_DID  minimum device identifier (DID) to read (default: 0x0000)
   --max_did MAX_DID  maximum device identifier (DID) to read (default: 0xFFFF)
 ```
+
+Example use:
+```
+$ caringcaribou uds dump_dids 0x7E0 0x7E8
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'uds'
+
+Dumping DIDs in range 0x0000-0xffff
+
+Identified DIDs:
+DID    Value (hex)
+0x0100 00
+0x0102 00
+0x0104 0000
+0x0105 0000
+0x0106 00
+0x0108 00
+0x011b 00000009000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0x0121 00000019
+0x0153 005eeec64500020000005ed8b8fb00020000005ec2957500020000005eb48d2a00020000005e84a2e800020000005e72aac700020000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+0x0154 005ef6a90e40000000005ef6a34040000000005ef6a2af40000000005ef6a25140000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+0x0155 005e84950204000000005e84950104000000005e84950104000000005e84950004000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+0x0261 00
+0x028d 0c19
+0x029e 0019
+0x02a0 00120000000000210000001e00000001000000340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0x02a1 00030000000000000000000000390000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0x02cd 00
+0x02ed 02010300000000000400
+0x02ee 04c00000000000000000
+...
+0x14d2 00
+0x14d4 0000
+0x14d8 61a7
+0x14f9 5a00
+0x1510 06
+0x1514 04
+0x1538 0000
+0x1558 01
+0x1588 08
+^C
+
+Terminated by user
+```
+
+
+## Security Seed
+Automated way for collecting the Seeds in given Diagnostic Session and Security Access level. You can also define the number of seeds to collect, as well as configure automatic resets and set the wait time between requests.
+
+```
+$ caringcaribou uds security_seed -h
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'uds'
+
+usage: caringcaribou uds security_seed [-h] [-r RTYPE] [-d D] [-n NUM] stype level src dst
+
+positional arguments:
+  stype                 Session Type: 1=defaultSession 2=programmingSession 3=extendedSession 4=safetySession [0x40-0x5F]=OEM
+                        [0x60-0x7E]=Supplier [0x0, 0x5-0x3F, 0x7F]=ISOSAEReserved
+  level                 Security level: [0x1-0x41 (odd only)]=OEM 0x5F=EOLPyrotechnics [0x61-0x7E]=Supplier [0x0, 0x43-0x5E,
+                        0x7F]=ISOSAEReserved
+  src                   arbitration ID to transmit to
+  dst                   arbitration ID to listen to
+
+options:
+  -h, --help            show this help message and exit
+  -r RTYPE, --reset RTYPE
+                        Enable reset between security seed requests. Valid RTYPE integers are: 1=hardReset, 2=key off/on, 3=softReset,
+                        4=enable rapid power shutdown, 5=disable rapid power shutdown. (default: None)
+  -d D, --delay D       Wait D seconds between reset and security seed request. You'll likely need to increase this when using RTYPE:
+                        1=hardReset. Does nothing if RTYPE is None. (default: 0.01)
+  -n NUM, --num NUM     Specify a positive number of security seeds to capture before terminating. A '0' is interpreted as infinity.
+                        (default: 0)
+```
+
+Example use for collecting 10 seeds in the Diagnostic Session 0x3 (Extended), and Security Access level 0x3:
+```
+$ caringcaribou uds security_seed -n 10 0x3 0x3 0x7E0 0x7E8
+
+-------------------
+CARING CARIBOU v0.x
+-------------------
+
+Loading module 'uds'
+
+Security seed dump started. Press Ctrl+C to stop.
+
+Seed received: 2190c8e4	(Total captured: 10)
+
+Security Access Seeds captured:
+8ac56231
+178bc5e2
+773b1d8e
+b2592c96
+a251a8d4
+2b95ca65
+eb753a9d
+1b8dc663
+b5daed76
+2190c8e4
+```
+
 
 ## Auto
 Performs a fully automated diagnostics scan from start to finish, by using the already existing CC modules.

--- a/documentation/uds.md
+++ b/documentation/uds.md
@@ -320,7 +320,7 @@ Terminated by user
 
 
 ## Security Seed
-Automated way for collecting the Seeds in given Diagnostic Session and Security Access level. You can also define the number of seeds to collect, as well as configure automatic resets and set the wait time between requests.
+An automated way to collect seeds for a specific security access level in a specific diagnostic session. You can also define the number of seeds to collect, as well as configure automatic resets and set the wait time between requests.
 
 ```
 $ caringcaribou uds security_seed -h


### PR DESCRIPTION
Documentation Update

README.md:
- reordered the list of modules, now the most basic modules are at the top, and the DCM module, which is no longer being developed, has been moved to the bottom.
- updated description for UDS.

dcm.py:
- added print for DeprecationWarning when running the scanner.

dcm.md:
- added information about the module being replaced by the UDS module.

howtouse.md:
- swapped paragraphs to maintain consistency of information.
- added missing modules to the list.
- replaced the DCM module with the UDS module in usage examples.
- expanded the usage example to include 'uds services'.

uds.md:
- added 'security_seed' to the list of available modes.
- added usage examples.

listener.md:
- added a usage example.


I hope to gradually add new usage examples for each mode in every module.